### PR TITLE
[TASK] Enhance towards multicore v11/v12 testing and jogging pieces to the right place

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,16 +16,12 @@ jobs:
     steps:
       - name: "Checkout"
         uses: actions/checkout@v3
-      - name: "Install PHP"
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: "${{ matrix.php-version }}"
-          coverage: none
-          tools: composer:v2.4
+      - name: "Set composer token"
+        run: "Build/Scripts/runTests.sh -p ${{ matrix.php-version }} -s composer -e 'config github-oauth.github.com ${{ github.token }}'"
       - name: "Show the Composer configuration"
-        run: "composer config --global --list"
+        run: "Build/Scripts/runTests.sh -t 11 -p ${{ matrix.php-version }} -s composer -e 'config --global --list'"
       - name: "Run PHP lint"
-        run: "composer ci:php:lint"
+        run: "Build/Scripts/runTests.sh -t 11 -p ${{ matrix.php-version }} -s composer -e 'ci:php:lint'"
     strategy:
       fail-fast: false
       matrix:
@@ -39,16 +35,12 @@ jobs:
     steps:
       - name: "Checkout"
         uses: actions/checkout@v3
-      - name: "Install PHP"
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: "${{ matrix.php-version }}"
-          coverage: none
-          tools: composer:v2.4
+      - name: "Set composer token"
+        run: "Build/Scripts/runTests.sh -p ${{ matrix.php-version }} -s composer -e 'config github-oauth.github.com ${{ github.token }}'"
       - name: "Show Composer version"
-        run: "composer --version"
+        run: "Build/Scripts/runTests.sh -t 11 -p ${{ matrix.php-version }} -s composer -e '--version'"
       - name: "Show the Composer configuration"
-        run: "composer config --global --list"
+        run: "Build/Scripts/runTests.sh -t 11 -p ${{ matrix.php-version }} -s composer -e 'config --global --list'"
       - name: "Cache dependencies installed with composer"
         uses: actions/cache@v3
         with:
@@ -56,14 +48,18 @@ jobs:
           path: ~/.cache/composer
           restore-keys: "php${{ matrix.php-version }}-composer-\n"
       - name: "Install Composer dependencies"
-        run: "composer install --no-progress"
+        run: "Build/Scripts/runTests.sh -t 11 -p ${{ matrix.php-version }} -s composerInstall"
       - name: "Run command"
-        run: "composer ci:${{ matrix.command }}"
+        run: "Build/Scripts/runTests.sh -t 11 -p ${{ matrix.php-version }} -s composer -e 'ci:${{ matrix.command }}'"
     strategy:
       fail-fast: false
       matrix:
         command:
-          - "composer:normalize"
+          # @todo disabled composer:normalize temporarly, as this does not work out due composer.json <-> lock
+          #       discrepancy with keep json file unchanged logic of runTests.sh. Does this tests make sense for
+          #       extension/package development as this does not have fixed composer.lock files, thus always having
+          #       valid composer.json <-> lock if not proceeded like runTests.sh ?
+          # - "composer:normalize"
           - "json:lint"
           - "php:copypaste"
           - "php:cs-fixer"
@@ -76,6 +72,8 @@ jobs:
   code-quality-frontend:
     name: "Code quality frontend checks"
     runs-on: ubuntu-22.04
+    env:
+      GITHUB_COMPOSER_TOKEN: ${{ github.token }}
     strategy:
       fail-fast: false
       matrix:
@@ -104,135 +102,128 @@ jobs:
     steps:
       - name: "Checkout"
         uses: actions/checkout@v3
-      - name: "Install PHP"
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: "${{ matrix.php-version }}"
-          coverage: none
-          tools: composer:v2.4
+      - name: "Set composer token"
+        run: "Build/Scripts/runTests.sh -p ${{ matrix.php-version }} -s composer -e 'config github-oauth.github.com ${{ github.token }}'"
       - name: "Show Composer version"
-        run: "composer --version"
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3-version }} -p ${{ matrix.php-version }} -s composer -e '--version'"
       - name: "Show the Composer configuration"
-        run: "composer config --global --list"
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3-version }} -p ${{ matrix.php-version }} -s composer -e 'config --global --list'"
       - name: "Cache dependencies installed with composer"
         uses: actions/cache@v3
         with:
           key: "php${{ matrix.php-version }}-typo3${{ matrix.typo3-version }}-${{ matrix.composer-dependencies }}-composer-${{ hashFiles('**/composer.json') }}"
           path: ~/.cache/composer
           restore-keys: "php${{ matrix.php-version }}-typo3${{ matrix.typo3-version }}-${{ matrix.composer-dependencies }}-composer-\n"
-      - name: "Install TYPO3 Core"
-        env:
-          TYPO3: "${{ matrix.typo3-version }}"
-        run: |
-          composer require --no-ansi --no-interaction --no-progress --no-install typo3/cms-core:"$TYPO3"
-          composer show
       - name: "Install lowest dependencies with composer"
         if: "matrix.composer-dependencies == 'lowest'"
-        run: |
-          composer update --no-ansi --no-interaction --no-progress --with-dependencies --prefer-lowest
-          composer show
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3-version }} -p ${{ matrix.php-version }} -s composerInstallLowest"
       - name: "Install highest dependencies with composer"
         if: "matrix.composer-dependencies == 'highest'"
-        run: |
-          composer update --no-ansi --no-interaction --no-progress --with-dependencies
-          composer show
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3-version }} -p ${{ matrix.php-version }} -s composerInstallHighest"
       - name: "Run unit tests"
-        run: "composer ci:tests:unit"
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3-version }} -p ${{ matrix.php-version }} -s unit"
     strategy:
       fail-fast: false
       matrix:
         include:
-          - typo3-version: "^11.5"
+          - typo3-version: "11"
             php-version: "7.4"
             composer-dependencies: lowest
-          - typo3-version: "^11.5"
+          - typo3-version: "11"
             php-version: "7.4"
             composer-dependencies: highest
-          - typo3-version: "^11.5"
+          - typo3-version: "11"
             php-version: "8.0"
             composer-dependencies: lowest
-          - typo3-version: "^11.5"
+          - typo3-version: "11"
             php-version: "8.0"
             composer-dependencies: highest
-          - typo3-version: "^11.5"
+          - typo3-version: "11"
             php-version: "8.1"
             composer-dependencies: lowest
-          - typo3-version: "^11.5"
+          - typo3-version: "11"
+            php-version: "8.1"
+            composer-dependencies: highest
+          - typo3-version: "12"
+            php-version: "8.1"
+            composer-dependencies: lowest
+          - typo3-version: "12"
             php-version: "8.1"
             composer-dependencies: highest
   functional-tests:
     name: "Functional tests"
     runs-on: ubuntu-22.04
     needs: php-lint
-    env:
-      DB_DATABASE: typo3
-      DB_USER: root
-      DB_PASSWORD: root
-      DB_HOST: localhost
     steps:
       - name: "Checkout"
         uses: actions/checkout@v3
-      - name: "Install PHP"
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: "${{ matrix.php-version }}"
-          tools: composer:v2.4
-          extensions: mysqli
-          coverage: none
+      - name: "Set composer token"
+        run: "Build/Scripts/runTests.sh -p ${{ matrix.php-version }} -s composer -e 'config github-oauth.github.com ${{ github.token }}'"
       - name: "Show Composer version"
-        run: "composer --version"
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3-version }} -p ${{ matrix.php-version }} -s composer -e '--version'"
       - name: "Show the Composer configuration"
-        run: "composer config --global --list"
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3-version }} -p ${{ matrix.php-version }} -s composer -e 'config --global --list'"
       - name: "Cache dependencies installed with composer"
         uses: actions/cache@v3
         with:
           key: "php${{ matrix.php-version }}-typo3${{ matrix.typo3-version }}-${{ matrix.composer-dependencies }}-composer-${{ hashFiles('**/composer.json') }}"
           path: ~/.cache/composer
           restore-keys: "php${{ matrix.php-version }}-typo3${{ matrix.typo3-version }}-${{ matrix.composer-dependencies }}-composer-\n"
-      - name: "Install TYPO3 Core"
-        env:
-          TYPO3: "${{ matrix.typo3-version }}"
-        run: |
-          composer require --no-ansi --no-interaction --no-progress --no-install typo3/cms-core:"$TYPO3"
-          composer show
+      - name: "Set composer token"
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3-version }} -p ${{ matrix.php-version }} -s composer -e 'config github-oauth.github.com ${{ secrets.GITHUB_TOKEN }}'"
       - name: "Install lowest dependencies with composer"
         if: "matrix.composer-dependencies == 'lowest'"
-        run: |
-          composer update --no-ansi --no-interaction --no-progress --with-dependencies --prefer-lowest
-          composer show
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3-version }} -p ${{ matrix.php-version }} -s composerInstallLowest"
       - name: "Install highest dependencies with composer"
         if: "matrix.composer-dependencies == 'highest'"
-        run: |
-          composer update --no-ansi --no-interaction --no-progress --with-dependencies
-          composer show
-      - name: "Start MySQL"
-        run: "sudo /etc/init.d/mysql start"
-      - name: "Run functional tests"
-        run: |
-          export typo3DatabaseName="$DB_DATABASE";
-          export typo3DatabaseHost="$DB_HOST";
-          export typo3DatabaseUsername="$DB_USER";
-          export typo3DatabasePassword="$DB_PASSWORD";
-          composer ci:tests:functional
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3-version }} -p ${{ matrix.php-version }} -s composerInstallHighest"
+      - name: "Run functional tests (sqlite)"
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3-version }} -p ${{ matrix.php-version }} -s functional -d sqlite"
+      - name: "Run functional tests (MySQL 5.5 mysqli)"
+        if: "matrix.typo3-version == '11'"
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3-version }} -p ${{ matrix.php-version }} -s functional -d mysql -a mysqli -j 5.5"
+      # TYPO3v12 has min requirement MySQL 8.0, so use this for minimum test compared to TYPO3v11 testing (MySQL 5.5) with mysqli
+      - name: "Run functional tests (MySQL 8.0 mysqli)"
+        if: "matrix.typo3-version == '12'"
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3-version }} -p ${{ matrix.php-version }} -s functional -d mysql -a mysqli -j 5.5"
+      - name: "Run functional tests (MySQL 8.0 pdo_mysql)"
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3-version }} -p ${{ matrix.php-version }} -s functional -d mysql -a pdo_mysql -j 8.0"
+      - name: "Run functional tests (MariaDB 10.2 mysqli)"
+        if: "matrix.typo3-version == '11'"
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3-version }} -p ${{ matrix.php-version }} -s functional -d mariadb -a mysqli -i 10.2"
+      # TYPO3v12 has min requirement MariaDB 10.3, so use this for minimum test compared to TYPO3v11 testing (MariaDB 10.2)
+      - name: "Run functional tests (MariaDB 10.3 mysqli)"
+        if: "matrix.typo3-version == '12'"
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3-version }} -p ${{ matrix.php-version }} -s functional -d mariadb -a mysqli -i 10.3"
+      - name: "Run functional tests (MariaDB 10.7 pdo_mysql)"
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3-version }} -p ${{ matrix.php-version }} -s functional -d mariadb -a pdo_mysql -i 10.7"
+      - name: "Run functional tests (PostgresSQL 10)"
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3-version }} -p ${{ matrix.php-version }} -s functional -d postgres -k 10"
     strategy:
       fail-fast: false
       matrix:
         include:
-          - typo3-version: "^11.5"
+          - typo3-version: "11"
             php-version: "7.4"
             composer-dependencies: lowest
-          - typo3-version: "^11.5"
+          - typo3-version: "11"
             php-version: "7.4"
             composer-dependencies: highest
-          - typo3-version: "^11.5"
+          - typo3-version: "11"
             php-version: "8.0"
             composer-dependencies: lowest
-          - typo3-version: "^11.5"
+          - typo3-version: "11"
             php-version: "8.0"
             composer-dependencies: highest
-          - typo3-version: "^11.5"
+          - typo3-version: "11"
             php-version: "8.1"
             composer-dependencies: lowest
-          - typo3-version: "^11.5"
+          - typo3-version: "11"
+            php-version: "8.1"
+            composer-dependencies: highest
+          - typo3-version: "12"
+            php-version: "8.1"
+            composer-dependencies: lowest
+          - typo3-version: "12"
             php-version: "8.1"
             composer-dependencies: highest

--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -65,7 +65,7 @@ jobs:
       - name: "Upload coverage results to Coveralls"
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./.Build/vendor/bin/php-coveralls --coverage_clover=build/logs/clover.xml -v
+        run: ./.Build/vendor/bin/php-coveralls --coverage_clover=./.Build/logs/clover.xml --json_path=./.Build/logs/coveralls-upload.json -v
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -10,11 +10,6 @@ jobs:
   code-coverage:
     name: "Calculate code coverage"
     runs-on: ubuntu-22.04
-    env:
-      DB_DATABASE: typo3
-      DB_USER: root
-      DB_PASSWORD: root
-      DB_HOST: localhost
     steps:
       - name: "Checkout"
         uses: actions/checkout@v3
@@ -25,43 +20,32 @@ jobs:
           tools: composer:v2.4
           extensions: xdebug, mysqli
           coverage: xdebug
+      - name: "Set composer token"
+        run: "Build/Scripts/runTests.sh -p ${{ matrix.php-version }} -s composer -e 'config github-oauth.github.com ${{ github.token }}'"
       - name: "Show Composer version"
-        run: composer --version
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3-version }} -p ${{ matrix.php-version }} -s composer -e '--version'"
+      - name: "Show the Composer configuration"
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3-version }} -p ${{ matrix.php-version }} -s composer -e 'config --global --list'"
       - name: "Cache dependencies installed with composer"
         uses: actions/cache@v3
         with:
           key: "php${{ matrix.php-version }}-typo3${{ matrix.typo3-version }}-${{ matrix.composer-dependencies }}-composer-${{ hashFiles('**/composer.json') }}"
           path: ~/.cache/composer
           restore-keys: "php${{ matrix.php-version }}-typo3${{ matrix.typo3-version }}-${{ matrix.composer-dependencies }}-composer-\n"
-      - name: "Install TYPO3 Core"
-        env:
-          TYPO3: "${{ matrix.typo3-version }}"
-        run: |
-          composer require --no-ansi --no-interaction --no-progress --no-install typo3/cms-core:"$TYPO3"
-          composer show
       - name: "Install lowest dependencies with composer"
         if: "matrix.composer-dependencies == 'lowest'"
-        run: |
-          composer update --no-ansi --no-interaction --no-progress --with-dependencies --prefer-lowest
-          composer show
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3-version }} -p ${{ matrix.php-version }} -s composerInstallLowest"
       - name: "Install highest dependencies with composer"
         if: "matrix.composer-dependencies == 'highest'"
-        run: |
-          composer update --no-ansi --no-interaction --no-progress --with-dependencies
-          composer show
-      - name: "Start MySQL"
-        run: "sudo /etc/init.d/mysql start"
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3-version }} -p ${{ matrix.php-version }} -s composerInstallHighest"
+      - name: "Create coverage directory structure"
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3-version }} -p ${{ matrix.php-version }} -s composer -e 'coverage:create-directories'"
       - name: "Run unit tests with coverage"
-        run: composer ci:coverage:unit
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3-version }} -p ${{ matrix.php-version }} -s unit -x -z 'coverage' -e '--whitelist Classes --coverage-php=.Build/coverage/unit.cov'"
       - name: "Run functional tests with coverage"
-        run: |
-          export typo3DatabaseName="$DB_DATABASE";
-          export typo3DatabaseHost="$DB_HOST";
-          export typo3DatabaseUsername="$DB_USER";
-          export typo3DatabasePassword="$DB_PASSWORD";
-          composer ci:coverage:functional
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3-version }} -p ${{ matrix.php-version }} -s functional -d mysql -a mysqli -j 8.0 -x -z 'coverage' -e '--whitelist Classes --coverage-php=.Build/coverage/functional.cov'"
       - name: "Merge coverage results"
-        run: composer ci:coverage:merge
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3-version }} -p ${{ matrix.php-version }} -s composer -e 'ci:coverage:merge'"
       - name: "Upload coverage results to Coveralls"
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -70,6 +54,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - typo3-version: "^11.5"
+          - typo3-version: "11"
             php-version: "7.4"
             composer-dependencies: highest

--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -17,7 +17,6 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ matrix.php-version }}"
-          tools: composer:v2.4
           extensions: xdebug, mysqli
           coverage: xdebug
       - name: "Set composer token"

--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -18,9 +18,10 @@ jobs:
         with:
           php-version: "${{ matrix.php-version }}"
           extensions: xdebug, mysqli
+          tools: composer:v2.4
           coverage: xdebug
       - name: "Set composer token"
-        run: "Build/Scripts/runTests.sh -p ${{ matrix.php-version }} -s composer -e 'config github-oauth.github.com ${{ github.token }}'"
+        run: "Build/Scripts/runTests.sh -p ${{ matrix.php-version }} -s composer -e 'config github-oauth.github.com ${{ secrets.GITHUB_TOKEN }}'"
       - name: "Show Composer version"
         run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3-version }} -p ${{ matrix.php-version }} -s composer -e '--version'"
       - name: "Show the Composer configuration"
@@ -44,11 +45,12 @@ jobs:
       - name: "Run functional tests with coverage"
         run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3-version }} -p ${{ matrix.php-version }} -s functional -d mysql -a mysqli -j 8.0 -x -z 'coverage' -e '--whitelist Classes --coverage-php=.Build/coverage/functional.cov'"
       - name: "Merge coverage results"
-        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3-version }} -p ${{ matrix.php-version }} -s composer -e 'ci:coverage:merge'"
+        #run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3-version }} -p ${{ matrix.php-version }} -s composer -e 'ci:coverage:merge'"
+        run: composer ci:coverage:merge
       - name: "Upload coverage results to Coveralls"
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./.Build/vendor/bin/php-coveralls --coverage_clover=./.Build/logs/clover.xml --json_path=./.Build/logs/coveralls-upload.json -v
+        run: ./.Build/vendor/bin/php-coveralls --coverage_clover=.Build/logs/clover.xml --json_path=.Build/logs/coveralls-upload.json -v
     strategy:
       fail-fast: false
       matrix:

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 /.php-cs-fixer.cache
 /.phpunit.result.cache
 /Documentation-GENERATED-temp/
-/build
 /clover.xml
 /composer.lock
 /nbproject

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /*.idea
+/.fleet
 /.Build/*
 /.php-cs-fixer.cache
 /.phpunit.result.cache

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,13 @@
 /*.idea
 /.fleet
 /.Build/*
+/.cache/*
 /.php-cs-fixer.cache
 /.phpunit.result.cache
+/Build/testing-docker/.env
 /Documentation-GENERATED-temp/
 /clover.xml
+/composer.json.*
 /composer.lock
 /nbproject
 /node_modules/

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -1,0 +1,480 @@
+#!/usr/bin/env bash
+
+#
+# TYPO3 core test runner based on docker and docker-compose.
+#
+
+# Function to write a .env file in Build/testing-docker
+# This is read by docker-compose and vars defined here are
+# used in Build/testing-docker/docker-compose.yml
+setUpDockerComposeDotEnv() {
+    # Delete possibly existing local .env file if exists
+    [ -e .env ] && rm .env
+    # Set up a new .env file for docker-compose
+    {
+        echo "COMPOSE_PROJECT_NAME=local"
+        # To prevent access rights of files created by the testing, the docker image later
+        # runs with the same user that is currently executing the script. docker-compose can't
+        # use $UID directly itself since it is a shell variable and not an env variable, so
+        # we have to set it explicitly here.
+        echo "HOST_UID=`id -u`"
+        # Your local user
+        echo "ROOT_DIR=${ROOT_DIR}"
+        echo "HOST_USER=${USER}"
+        echo "TEST_FILE=${TEST_FILE}"
+        echo "TYPO3_VERSION=${TYPO3_VERSION}"
+        echo "PHP_XDEBUG_ON=${PHP_XDEBUG_ON}"
+        echo "PHP_XDEBUG_PORT=${PHP_XDEBUG_PORT}"
+        echo "DOCKER_PHP_IMAGE=${DOCKER_PHP_IMAGE}"
+        echo "EXTRA_TEST_OPTIONS=${EXTRA_TEST_OPTIONS}"
+        echo "SCRIPT_VERBOSE=${SCRIPT_VERBOSE}"
+        echo "CGLCHECK_DRY_RUN=${CGLCHECK_DRY_RUN}"
+        echo "DATABASE_DRIVER=${DATABASE_DRIVER}"
+        echo "MARIADB_VERSION=${MARIADB_VERSION}"
+        echo "MYSQL_VERSION=${MYSQL_VERSION}"
+        echo "POSTGRES_VERSION=${POSTGRES_VERSION}"
+        echo "USED_XDEBUG_MODES=${USED_XDEBUG_MODES}"
+        # needed for coveralls upload
+        echo "COVERALLS_REPO_TOKEN='${COVERALLS_REPO_TOKEN}'"
+        echo "GITHUB_REF='${GITHUB_REF}'"
+        echo "GITHUB_ACTIONS='${GITHUB_ACTIONS}'"
+        echo "GITHUB_RUN_ID='${GITHUB_RUN_ID}'"
+        echo "GITHUB_EVENT_NAME='${GITHUB_EVENT_NAME}'"
+    } > .env
+}
+
+# Options -a and -d depend on each other. The function
+# validates input combinations and sets defaults.
+handleDbmsAndDriverOptions() {
+    case ${DBMS} in
+        mysql|mariadb)
+            [ -z "${DATABASE_DRIVER}" ] && DATABASE_DRIVER="mysqli"
+            if [ "${DATABASE_DRIVER}" != "mysqli" ] && [ "${DATABASE_DRIVER}" != "pdo_mysql" ]; then
+                echo "Invalid option -a ${DATABASE_DRIVER} with -d ${DBMS}" >&2
+                echo >&2
+                echo "call \"./Build/Scripts/runTests.sh -h\" to display help and valid options" >&2
+                exit 1
+            fi
+            ;;
+        postgres|sqlite)
+            if [ -n "${DATABASE_DRIVER}" ]; then
+                echo "Invalid option -a ${DATABASE_DRIVER} with -d ${DBMS}" >&2
+                echo >&2
+                echo "call \"./Build/Scripts/runTests.sh -h\" to display help and valid options" >&2
+                exit 1
+            fi
+            ;;
+    esac
+}
+
+# Load help text into $HELP
+read -r -d '' HELP <<EOF
+ttn/tea test runner. Execute unit test suite and some other details.
+Also used by github for test execution.
+
+Recommended docker version is >=20.10 for xdebug break pointing to work reliably, and
+a recent docker-compose (tested >=1.21.2) is needed.
+
+Usage: $0 [options] [file]
+
+No arguments: Run all unit tests with PHP 7.4
+
+Options:
+    -s <...>
+        Specifies which test suite to run
+            - cgl: cgl test and fix all php files
+            - clean: clean up build and testing related files
+            - composer: Execute "composer" command, using -e for command arguments pass-through, ex. -e "ci:php:stan"
+            - composerInstall: "composer update", handy if host has no PHP
+            - composerInstallLowest: "composer update", handy if host has no PHP
+            - composerInstallHighest: "composer update", handy if host has no PHP
+            - coveralls: Execute coveralls to upload coverage to coveralls
+            - functional: functional tests
+            - lint: PHP linting
+            - phpstan: phpstan analyze
+            - phpstanGenerateBaseline: regenerate phpstan baseline, handy after phpstan updates
+            - unit: PHP unit tests
+
+    -a <mysqli|pdo_mysql>
+        Only with -s acceptance,functional
+        Specifies to use another driver, following combinations are available:
+            - mysql
+                - mysqli (default)
+                - pdo_mysql
+            - mariadb
+                - mysqli (default)
+                - pdo_mysql
+
+    -d <sqlite|mariadb|mysql|postgres>
+        Only with -s acceptance,functional
+        Specifies on which DBMS tests are performed
+            - sqlite: (default) use sqlite
+            - mariadb: use mariadb
+            - mysql: use mysql
+            - postgres: use postgres
+
+    -i <10.2|10.3|10.4|10.5|10.6|10.7>
+        Only with -d mariadb
+        Specifies on which version of mariadb tests are performed
+            - 10.2 (default)
+            - 10.3
+            - 10.4
+            - 10.5
+            - 10.6
+            - 10.7
+
+    -j <5.5|5.6|5.7|8.0>
+        Only with -d mysql
+        Specifies on which version of mysql tests are performed
+            - 5.5 (default)
+            - 5.6
+            - 5.7
+            - 8.0
+
+    -k <10|11|12|13|14>
+        Only with -d postgres
+        Specifies on which version of postgres tests are performed
+            - 10 (default)
+            - 11
+            - 12
+            - 13
+            - 14
+
+    -p <7.4|8.0|8.1|8.2>
+        Specifies the PHP minor version to be used
+            - 7.4 (default): use PHP 7.4
+            - 8.0: use PHP 8.0
+            - 8.1: use PHP 8.1
+            - 8.2: use PHP 8.2
+
+    -t <11|12>
+        Only with -s composerUpdate
+        Specifies the TYPO3 core major version to be used
+            - 11 (default): use TYPO3 core v11
+            - 12: use TYPO3 core v12
+
+    -e "<composer, phpunit or codeception options>"
+        Only with -s functional|unit|composer
+        Additional options to send to phpunit (unit & functional tests) or codeception (acceptance
+        tests). For phpunit, options starting with "--" must be added after options starting with "-".
+        Example -e "-v --filter canRetrieveValueWithGP" to enable verbose output AND filter tests
+        named "canRetrieveValueWithGP"
+
+    -x
+        Only with -s functional|unit
+        Send information to host instance for test or system under test break points. This is especially
+        useful if a local PhpStorm instance is listening on default xdebug port 9003. A different port
+        can be selected with -y
+
+    -y <port>
+        Send xdebug information to a different port than default 9003 if an IDE like PhpStorm
+        is not listening on default port.
+
+    -z <xdebug modes>
+        Only with -x and -s functional|unit|acceptance
+        This sets the used xdebug modes. Defaults to 'debug,develop'
+
+    -n
+        Only with -s cgl
+        Activate dry-run in CGL check that does not actively change files and only prints broken ones.
+
+    -u
+        Update existing typo3/core-testing-*:latest docker images. Maintenance call to docker pull latest
+        versions of the main php images. The images are updated once in a while and only the youngest
+        ones are supported by core testing. Use this if weird test errors occur. Also removes obsolete
+        image versions of typo3/core-testing-*.
+
+    -v
+        Enable verbose script output. Shows variables and docker commands.
+
+    -h
+        Show this help.
+
+Examples:
+    # Run unit tests using PHP 7.4
+    ./Build/Scripts/runTests.sh -s unit
+EOF
+
+# Test if docker-compose exists, else exit out with error
+if ! type "docker-compose" > /dev/null; then
+  echo "This script relies on docker and docker-compose. Please install" >&2
+  exit 1
+fi
+
+# Go to the directory this script is located, so everything else is relative
+# to this dir, no matter from where this script is called.
+THIS_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+cd "$THIS_SCRIPT_DIR" || exit 1
+
+# Go to directory that contains the local docker-compose.yml file
+cd ../testing-docker || exit 1
+
+# Option defaults
+if ! command -v realpath &> /dev/null; then
+  echo "This script works best with realpath installed" >&2
+  ROOT_DIR="${PWD}/../../"
+else
+  ROOT_DIR=`realpath ${PWD}/../../`
+fi
+TEST_SUITE=""
+DBMS="sqlite"
+PHP_VERSION="7.4"
+TYPO3_VERSION="11"
+PHP_XDEBUG_ON=0
+PHP_XDEBUG_PORT=9003
+EXTRA_TEST_OPTIONS=""
+SCRIPT_VERBOSE=0
+CGLCHECK_DRY_RUN=""
+DATABASE_DRIVER=""
+MARIADB_VERSION="10.2"
+MYSQL_VERSION="5.5"
+POSTGRES_VERSION="10"
+USED_XDEBUG_MODES="debug,develop"
+
+# Option parsing
+# Reset in case getopts has been used previously in the shell
+OPTIND=1
+# Array for invalid options
+INVALID_OPTIONS=();
+# Simple option parsing based on getopts (! not getopt)
+while getopts ":s:a:d:i:j:k:p:t:e:xy:z:nhuv" OPT; do
+    case ${OPT} in
+        s)
+            TEST_SUITE=${OPTARG}
+            ;;
+        a)
+            DATABASE_DRIVER=${OPTARG}
+            ;;
+        d)
+            DBMS=${OPTARG}
+            ;;
+        i)
+            MARIADB_VERSION=${OPTARG}
+            if ! [[ ${MARIADB_VERSION} =~ ^(10.2|10.3|10.4|10.5|10.6|10.7)$ ]]; then
+                INVALID_OPTIONS+=("${OPTARG}")
+            fi
+            ;;
+        j)
+            MYSQL_VERSION=${OPTARG}
+            if ! [[ ${MYSQL_VERSION} =~ ^(5.5|5.6|5.7|8.0)$ ]]; then
+                INVALID_OPTIONS+=("${OPTARG}")
+            fi
+            ;;
+        k)
+            POSTGRES_VERSION=${OPTARG}
+            if ! [[ ${POSTGRES_VERSION} =~ ^(10|11|12|13|14)$ ]]; then
+                INVALID_OPTIONS+=("${OPTARG}")
+            fi
+            ;;
+        p)
+            PHP_VERSION=${OPTARG}
+            if ! [[ ${PHP_VERSION} =~ ^(7.4|8.0|8.1|8.2)$ ]]; then
+                INVALID_OPTIONS+=("p ${OPTARG}")
+            fi
+            ;;
+        t)
+            TYPO3_VERSION=${OPTARG}
+            if ! [[ ${TYPO3_VERSION} =~ ^(11|12)$ ]]; then
+                INVALID_OPTIONS+=("p ${OPTARG}")
+            fi
+            ;;
+        e)
+            EXTRA_TEST_OPTIONS=${OPTARG}
+            ;;
+        x)
+            PHP_XDEBUG_ON=1
+            ;;
+        y)
+            PHP_XDEBUG_PORT=${OPTARG}
+            ;;
+        z)
+            USED_XDEBUG_MODES=${OPTARG}
+            ;;
+        h)
+            echo "${HELP}"
+            exit 0
+            ;;
+        n)
+            CGLCHECK_DRY_RUN="-n"
+            ;;
+        u)
+            TEST_SUITE=update
+            ;;
+        v)
+            SCRIPT_VERBOSE=1
+            ;;
+        \?)
+            INVALID_OPTIONS+=(${OPTARG})
+            ;;
+        :)
+            INVALID_OPTIONS+=(${OPTARG})
+            ;;
+    esac
+done
+
+# Exit on invalid options
+if [ ${#INVALID_OPTIONS[@]} -ne 0 ]; then
+    echo "Invalid option(s):" >&2
+    for I in "${INVALID_OPTIONS[@]}"; do
+        echo "-"${I} >&2
+    done
+    echo >&2
+    echo "${HELP}" >&2
+    exit 1
+fi
+
+# Move "7.2" to "php72", the latter is the docker container name
+DOCKER_PHP_IMAGE=`echo "php${PHP_VERSION}" | sed -e 's/\.//'`
+
+# Set $1 to first mass argument, this is the optional test file or test directory to execute
+shift $((OPTIND - 1))
+TEST_FILE=${1}
+if [ -n "${1}" ]; then
+    TEST_FILE=".Build/public/typo3conf/ext/tea/${1}"
+fi
+
+if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
+    set -x
+fi
+
+if [ -z ${TEST_SUITE} ]; then
+    echo "${HELP}"
+    exit 0
+fi
+
+# Suite execution
+case ${TEST_SUITE} in
+    cgl)
+        # Active dry-run for cgl needs not "-n" but specific options
+        if [[ ! -z ${CGLCHECK_DRY_RUN} ]]; then
+            CGLCHECK_DRY_RUN="--dry-run --diff"
+        fi
+        setUpDockerComposeDotEnv
+        docker-compose run cgl
+        SUITE_EXIT_CODE=$?
+        docker-compose down
+        ;;
+    clean)
+        rm -rf ../../.cache ../../composer.lock ../../.Build/ ../../Tests/Acceptance/Support/_generated/ ../../composer.json.testing
+        ;;
+    composer)
+        setUpDockerComposeDotEnv
+        docker-compose run composer
+        SUITE_EXIT_CODE=$?
+        docker-compose down
+        ;;
+    composerInstall)
+        setUpDockerComposeDotEnv
+        cp ../../composer.json ../../composer.json.orig
+        if [ -f "../../composer.json.testing" ]; then
+            cp ../../composer.json ../../composer.json.orig
+        fi
+        docker-compose run composer_install
+        cp ../../composer.json ../../composer.json.testing
+        mv ../../composer.json.orig ../../composer.json
+        SUITE_EXIT_CODE=$?
+        docker-compose down
+        ;;
+    composerInstallLowest)
+        setUpDockerComposeDotEnv
+        cp ../../composer.json ../../composer.json.orig
+        if [ -f "../../composer.json.testing" ]; then
+            cp ../../composer.json ../../composer.json.orig
+        fi
+        docker-compose run composer_install_lowest
+        cp ../../composer.json ../../composer.json.testing
+        mv ../../composer.json.orig ../../composer.json
+        SUITE_EXIT_CODE=$?
+        docker-compose down
+        ;;
+    composerInstallHighest)
+        setUpDockerComposeDotEnv
+        cp ../../composer.json ../../composer.json.orig
+        if [ -f "../../composer.json.testing" ]; then
+            cp ../../composer.json ../../composer.json.orig
+        fi
+        docker-compose run composer_install_highest
+        cp ../../composer.json ../../composer.json.testing
+        mv ../../composer.json.orig ../../composer.json
+        SUITE_EXIT_CODE=$?
+        docker-compose down
+        ;;
+    coveralls)
+        setUpDockerComposeDotEnv
+        docker-compose run coveralls
+        SUITE_EXIT_CODE=$?
+        docker-compose down
+        ;;
+    functional)
+        handleDbmsAndDriverOptions
+        setUpDockerComposeDotEnv
+        case ${DBMS} in
+            mariadb)
+                echo "Using driver: ${DATABASE_DRIVER}"
+                docker-compose run functional_mariadb
+                SUITE_EXIT_CODE=$?
+                ;;
+            mysql)
+                echo "Using driver: ${DATABASE_DRIVER}"
+                docker-compose run functional_mysql
+                SUITE_EXIT_CODE=$?
+                ;;
+            postgres)
+                docker-compose run functional_postgres
+                SUITE_EXIT_CODE=$?
+                ;;
+            sqlite)
+                # sqlite has a tmpfs as Web/typo3temp/var/tests/functional-sqlite-dbs/
+                # Since docker is executed as root (yay!), the path to this dir is owned by
+                # root if docker creates it. Thank you, docker. We create the path beforehand
+                # to avoid permission issues.
+                mkdir -p ${ROOT_DIR}/public/typo3temp/var/tests/functional-sqlite-dbs/
+                docker-compose run functional_sqlite
+                SUITE_EXIT_CODE=$?
+                ;;
+            *)
+                echo "Invalid -d option argument ${DBMS}" >&2
+                echo >&2
+                echo "${HELP}" >&2
+                exit 1
+        esac
+        docker-compose down
+        ;;
+    lint)
+        setUpDockerComposeDotEnv
+        docker-compose run lint
+        SUITE_EXIT_CODE=$?
+        docker-compose down
+        ;;
+    phpstan)
+        setUpDockerComposeDotEnv
+        docker-compose run phpstan
+        SUITE_EXIT_CODE=$?
+        docker-compose down
+        ;;
+    phpstanGenerateBaseline)
+        setUpDockerComposeDotEnv
+        docker-compose run phpstan_generate_baseline
+        SUITE_EXIT_CODE=$?
+        docker-compose down
+        ;;
+    unit)
+        setUpDockerComposeDotEnv
+        docker-compose run unit
+        SUITE_EXIT_CODE=$?
+        docker-compose down
+        ;;
+    update)
+        # pull typo3/core-testing-*:latest versions of those ones that exist locally
+        docker images typo3/core-testing-*:latest --format "{{.Repository}}:latest" | xargs -I {} docker pull {}
+        # remove "dangling" typo3/core-testing-* images (those tagged as <none>)
+        docker images typo3/core-testing-* --filter "dangling=true" --format "{{.ID}}" | xargs -I {} docker rmi {}
+        ;;
+    *)
+        echo "Invalid -s option argument ${TEST_SUITE}" >&2
+        echo >&2
+        echo "${HELP}" >&2
+        exit 1
+esac
+
+exit $SUITE_EXIT_CODE

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -34,12 +34,6 @@ setUpDockerComposeDotEnv() {
         echo "MYSQL_VERSION=${MYSQL_VERSION}"
         echo "POSTGRES_VERSION=${POSTGRES_VERSION}"
         echo "USED_XDEBUG_MODES=${USED_XDEBUG_MODES}"
-        # needed for coveralls upload
-        echo "COVERALLS_REPO_TOKEN='${COVERALLS_REPO_TOKEN}'"
-        echo "GITHUB_REF='${GITHUB_REF}'"
-        echo "GITHUB_ACTIONS='${GITHUB_ACTIONS}'"
-        echo "GITHUB_RUN_ID='${GITHUB_RUN_ID}'"
-        echo "GITHUB_EVENT_NAME='${GITHUB_EVENT_NAME}'"
     } > .env
 }
 

--- a/Build/phpunit/FunctionalTests.xml
+++ b/Build/phpunit/FunctionalTests.xml
@@ -1,0 +1,52 @@
+<!--
+    Functional test suite setup
+
+    Functional tests should extend \TYPO3\TestingFramework\Core\Tests\FunctionalTestCase,
+    take a look at this class for further documentation on how to run the suite.
+
+    TYPO3 CMS functional test suite also needs phpunit bootstrap code, the
+    file is located next to this .xml as FunctionalTestsBootstrap.php
+-->
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
+    backupGlobals="true"
+    bootstrap="FunctionalTestsBootstrap.php"
+    cacheResult="false"
+    colors="true"
+    convertErrorsToExceptions="true"
+    convertWarningsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertDeprecationsToExceptions="true"
+    forceCoversAnnotation="false"
+    stopOnError="false"
+    stopOnFailure="false"
+    stopOnIncomplete="false"
+    stopOnSkipped="false"
+    verbose="false"
+    beStrictAboutTestsThatDoNotTestAnything="false"
+    failOnWarning="true"
+    failOnRisky="true"
+>
+    <testsuites>
+        <testsuite name="Functional tests">
+            <!--
+                This path either needs an adaption in extensions, or an extension's
+                test location path needs to be given to phpunit.
+            -->
+            <directory>../../Tests/Functional/</directory>
+        </testsuite>
+    </testsuites>
+    <php>
+        <!--
+            @deprecated: Set this to not suppress warnings, notices and deprecations in functional tests
+                         with TYPO3 core v11 and up.
+                         Will always be done with next major version.
+                         To still suppress warnings, notices and deprecations, do NOT define the constant at all.
+         -->
+        <const name="TYPO3_TESTING_FUNCTIONAL_REMOVE_ERROR_HANDLER" value="true" />
+        <ini name="display_errors" value="1" />
+        <ini name="error_reporting" value="E_ALL" />
+        <env name="TYPO3_CONTEXT" value="Testing" />
+    </php>
+</phpunit>

--- a/Build/phpunit/FunctionalTestsBootstrap.php
+++ b/Build/phpunit/FunctionalTestsBootstrap.php
@@ -1,0 +1,30 @@
+<?php
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+/**
+ * Boilerplate for a functional test phpunit boostrap file.
+ *
+ * This file is loosely maintained within TYPO3 testing-framework, extensions
+ * are encouraged to not use it directly, but to copy it to an own place,
+ * usually in parallel to a FunctionalTests.xml file.
+ *
+ * This file is defined in FunctionalTests.xml and called by phpunit
+ * before instantiating the test suites.
+ */
+(static function () {
+    $testbase = new \TYPO3\TestingFramework\Core\Testbase();
+    $testbase->defineOriginalRootPath();
+    $testbase->createDirectory(ORIGINAL_ROOT . 'typo3temp/var/tests');
+    $testbase->createDirectory(ORIGINAL_ROOT . 'typo3temp/var/transient');
+})();

--- a/Build/phpunit/UnitTests.xml
+++ b/Build/phpunit/UnitTests.xml
@@ -1,0 +1,45 @@
+<!--
+    Unit test suite setup.
+
+    Unit tests should extend \TYPO3\TestingFramework\Core\Tests\UnitTestCase,
+    take a look at this class for further documentation on how to run the suite.
+
+    TYPO3 CMS unit test suite also needs phpunit bootstrap code, the
+    file is located next to this .xml as UnitTestsBootstrap.php
+-->
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
+    backupGlobals="true"
+    bootstrap="UnitTestsBootstrap.php"
+    cacheResult="false"
+    colors="true"
+    convertDeprecationsToExceptions="true"
+    convertErrorsToExceptions="true"
+    convertWarningsToExceptions="true"
+    convertNoticesToExceptions="true"
+    forceCoversAnnotation="false"
+    processIsolation="false"
+    stopOnError="false"
+    stopOnFailure="false"
+    stopOnIncomplete="false"
+    stopOnSkipped="false"
+    verbose="false"
+    beStrictAboutTestsThatDoNotTestAnything="true"
+    failOnWarning="true"
+    failOnRisky="true"
+>
+    <testsuites>
+        <testsuite name="Unit tests">
+            <!--
+                This path either needs an adaption in extensions, or an extension's
+                test location path needs to be given to phpunit.
+            -->
+            <directory>../../Tests/Unit/</directory>
+        </testsuite>
+    </testsuites>
+    <php>
+        <ini name="display_errors" value="1" />
+        <env name="TYPO3_CONTEXT" value="Testing" />
+    </php>
+</phpunit>

--- a/Build/phpunit/UnitTestsBootstrap.php
+++ b/Build/phpunit/UnitTestsBootstrap.php
@@ -1,0 +1,84 @@
+<?php
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+/**
+ * Boilerplate for a unit test phpunit boostrap file.
+ *
+ * This file is loosely maintained within TYPO3 testing-framework, extensions
+ * are encouraged to not use it directly, but to copy it to an own place,
+ * usually in parallel to a UnitTests.xml file.
+ *
+ * This file is defined in UnitTests.xml and called by phpunit
+ * before instantiating the test suites.
+ *
+ * The recommended way to execute the suite is "runTests.sh". See the
+ * according script within TYPO3 core's Build/Scripts directory and
+ * adapt to extensions needs.
+ */
+(static function () {
+    $testbase = new \TYPO3\TestingFramework\Core\Testbase();
+
+    // These if's are for core testing (package typo3/cms) only. cms-composer-installer does
+    // not create the autoload-include.php file that sets these env vars and sets composer
+    // mode to true. testing-framework can not be used without composer anyway, so it is safe
+    // to do this here. This way it does not matter if 'bin/phpunit' or 'vendor/phpunit/phpunit/phpunit'
+    // is called to run the tests since the 'relative to entry script' path calculation within
+    // SystemEnvironmentBuilder is not used. However, the binary must be called from the document
+    // root since getWebRoot() uses 'getcwd()'.
+    if (!getenv('TYPO3_PATH_ROOT')) {
+        putenv('TYPO3_PATH_ROOT=' . rtrim($testbase->getWebRoot(), '/'));
+    }
+    if (!getenv('TYPO3_PATH_WEB')) {
+        putenv('TYPO3_PATH_WEB=' . rtrim($testbase->getWebRoot(), '/'));
+    }
+
+    $testbase->defineSitePath();
+
+    $requestType = \TYPO3\CMS\Core\Core\SystemEnvironmentBuilder::REQUESTTYPE_BE | \TYPO3\CMS\Core\Core\SystemEnvironmentBuilder::REQUESTTYPE_CLI;
+    \TYPO3\TestingFramework\Core\SystemEnvironmentBuilder::run(0, $requestType);
+
+    $testbase->createDirectory(\TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/typo3conf/ext');
+    $testbase->createDirectory(\TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/typo3temp/assets');
+    $testbase->createDirectory(\TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/typo3temp/var/tests');
+    $testbase->createDirectory(\TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/typo3temp/var/transient');
+
+    // Retrieve an instance of class loader and inject to core bootstrap
+    $classLoader = require $testbase->getPackagesPath() . '/autoload.php';
+    \TYPO3\CMS\Core\Core\Bootstrap::initializeClassLoader($classLoader);
+
+    // Initialize default TYPO3_CONF_VARS
+    $configurationManager = new \TYPO3\CMS\Core\Configuration\ConfigurationManager();
+    $GLOBALS['TYPO3_CONF_VARS'] = $configurationManager->getDefaultConfiguration();
+
+    $cache = new \TYPO3\CMS\Core\Cache\Frontend\PhpFrontend(
+        'core',
+        new \TYPO3\CMS\Core\Cache\Backend\NullBackend('production', [])
+    );
+
+    // Set all packages to active
+    if (interface_exists(\TYPO3\CMS\Core\Package\Cache\PackageCacheInterface::class)) {
+        $packageManager = \TYPO3\CMS\Core\Core\Bootstrap::createPackageManager(\TYPO3\CMS\Core\Package\UnitTestPackageManager::class, \TYPO3\CMS\Core\Core\Bootstrap::createPackageCache($cache));
+    } else {
+        // v10 compatibility layer
+        // @deprecated Will be removed when v10 compat is dropped from testing-framework
+        $packageManager = \TYPO3\CMS\Core\Core\Bootstrap::createPackageManager(\TYPO3\CMS\Core\Package\UnitTestPackageManager::class, $cache);
+    }
+
+    \TYPO3\CMS\Core\Utility\GeneralUtility::setSingletonInstance(\TYPO3\CMS\Core\Package\PackageManager::class, $packageManager);
+    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::setPackageManager($packageManager);
+
+    $testbase->dumpClassLoadingInformation();
+
+    \TYPO3\CMS\Core\Utility\GeneralUtility::purgeInstances();
+})();

--- a/Build/testing-docker/docker-compose.yml
+++ b/Build/testing-docker/docker-compose.yml
@@ -367,7 +367,8 @@ services:
           set -x
         fi
         php -v | grep '^PHP';
-        php -dxdebug.mode=off .Build/vendor/bin/php-coveralls --coverage_clover=./.Build/logs/clover.xml --json_path=./.Build/logs/coveralls-upload.json -v
+        XDEBUG_MODE=\"coverage\" \
+        php -dxdebug.mode=off ./.Build/vendor/bin/php-coveralls --coverage_clover=./.Build/logs/clover.xml --json_path=./.Build/logs/coveralls-upload.json -v
       "
 
   phpstan:

--- a/Build/testing-docker/docker-compose.yml
+++ b/Build/testing-docker/docker-compose.yml
@@ -1,0 +1,411 @@
+version: '2.3'
+services:
+  #---------------------------------------------------------------------------------------------------------------------
+  # additional services needed for functional tests to be linked, e.g. databases
+  #---------------------------------------------------------------------------------------------------------------------
+  mysql:
+    image: mysql:${MYSQL_VERSION}
+    environment:
+      MYSQL_ROOT_PASSWORD: funcp
+    tmpfs:
+      - /var/lib/mysql/:rw,noexec,nosuid
+
+  mariadb:
+    image: mariadb:${MARIADB_VERSION}
+    environment:
+      MYSQL_ROOT_PASSWORD: funcp
+    tmpfs:
+      - /var/lib/mysql/:rw,noexec,nosuid
+
+  postgres:
+    image: postgres:${POSTGRES_VERSION}-alpine
+    environment:
+      POSTGRES_PASSWORD: funcp
+      POSTGRES_USER: funcu
+    tmpfs:
+      - /var/lib/postgresql/data:rw,noexec,nosuid
+
+  #---------------------------------------------------------------------------------------------------------------------
+  # composer related services
+  #---------------------------------------------------------------------------------------------------------------------
+  composer:
+    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    user: "${HOST_UID}"
+    volumes:
+      - ${ROOT_DIR}:${ROOT_DIR}
+    working_dir: ${ROOT_DIR}
+    environment:
+      COMPOSER_HOME: ".cache/composer-home"
+      COMPOSER_CACHE_DIR: ".cache/composer"
+    command: >
+      /bin/sh -c "
+        if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
+          set -x
+        fi
+        php -v | grep '^PHP';
+        composer ${EXTRA_TEST_OPTIONS};
+      "
+
+  composer_install:
+    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    user: "${HOST_UID}"
+    volumes:
+      - ${ROOT_DIR}:${ROOT_DIR}
+    working_dir: ${ROOT_DIR}
+    environment:
+      COMPOSER_HOME: ".cache/composer-home"
+      COMPOSER_CACHE_DIR: ".cache/composer"
+    command: >
+      /bin/sh -c "
+        if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
+          set -x
+        fi
+        php -v | grep '^PHP';
+        if [ ${TYPO3_VERSION} -eq 11 ]; then
+          composer require --no-ansi --no-interaction --no-progress --no-install \
+            typo3/cms-core:^11.5.4
+        fi
+        if [ ${TYPO3_VERSION} -eq 12 ]; then
+          composer require --no-ansi --no-interaction --no-progress --no-install \
+            typo3/cms-core:^12.0
+        fi
+        composer install --no-progress;
+      "
+
+  composer_install_lowest:
+    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    user: "${HOST_UID}"
+    volumes:
+      - ${ROOT_DIR}:${ROOT_DIR}
+    working_dir: ${ROOT_DIR}
+    environment:
+      COMPOSER_HOME: ".cache/composer-home"
+      COMPOSER_CACHE_DIR: ".cache/composer"
+    command: >
+      /bin/sh -c "
+        if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
+          set -x
+        fi
+        php -v | grep '^PHP';
+        if [ ${TYPO3_VERSION} -eq 11 ]; then
+          composer require --no-ansi --no-interaction --no-progress --no-install \
+            typo3/cms-core:^11.5.4
+        fi
+        if [ ${TYPO3_VERSION} -eq 12 ]; then
+          composer require --no-ansi --no-interaction --no-progress --no-install \
+            typo3/cms-core:^12.0
+        fi
+        composer update --no-ansi --no-interaction --no-progress --with-dependencies --prefer-lowest;
+        composer show;
+      "
+
+  composer_install_highest:
+    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    user: "${HOST_UID}"
+    volumes:
+      - ${ROOT_DIR}:${ROOT_DIR}
+    working_dir: ${ROOT_DIR}
+    environment:
+      COMPOSER_HOME: ".cache/composer-home"
+      COMPOSER_CACHE_DIR: ".cache/composer"
+    command: >
+      /bin/sh -c "
+        if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
+          set -x
+        fi
+        if [ ${TYPO3_VERSION} -eq 11 ]; then
+          composer require --no-ansi --no-interaction --no-progress --no-install \
+            typo3/cms-core:^11.5.4
+        fi
+        if [ ${TYPO3_VERSION} -eq 12 ]; then
+          composer require --no-ansi --no-interaction --no-progress --no-install \
+            typo3/cms-core:^12.0
+        fi
+        composer update --no-progress --no-interaction;
+        composer show;
+      "
+
+  #---------------------------------------------------------------------------------------------------------------------
+  # unit tests
+  #---------------------------------------------------------------------------------------------------------------------
+  unit:
+    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    user: "${HOST_UID}"
+    volumes:
+      - ${ROOT_DIR}:${ROOT_DIR}
+    working_dir: ${ROOT_DIR}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    environment:
+      COMPOSER_HOME: ".cache/composer-home"
+      COMPOSER_CACHE_DIR: ".cache/composer"
+    command: >
+      /bin/sh -c "
+        if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
+          set -x
+        fi
+        php -v | grep '^PHP';
+        if [ ${PHP_XDEBUG_ON} -eq 0 ]; then
+          XDEBUG_MODE=\"off\" \
+          .Build/vendor/bin/phpunit -c Build/phpunit/UnitTests.xml ${EXTRA_TEST_OPTIONS} ${TEST_FILE};
+        else
+          XDEBUG_MODE=\"${USED_XDEBUG_MODES}\" \
+          XDEBUG_TRIGGER=\"foo\" \
+          XDEBUG_CONFIG=\"client_host=host.docker.internal\" \
+          .Build/vendor/bin/phpunit -c Build/phpunit/UnitTests.xml ${EXTRA_TEST_OPTIONS} ${TEST_FILE};
+        fi
+      "
+
+  #---------------------------------------------------------------------------------------------------------------------
+  # functional tests against different dbms
+  #---------------------------------------------------------------------------------------------------------------------
+  functional_sqlite:
+    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    user: "${HOST_UID}"
+    volumes:
+      - ${ROOT_DIR}:${ROOT_DIR}
+    tmpfs:
+      - ${ROOT_DIR}/public/typo3temp/var/tests/functional-sqlite-dbs/:rw,noexec,nosuid,uid=${HOST_UID}
+    environment:
+      typo3DatabaseDriver: pdo_sqlite
+      COMPOSER_HOME: ".cache/composer-home"
+      COMPOSER_CACHE_DIR: ".cache/composer"
+    working_dir: ${ROOT_DIR}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    command: >
+      /bin/sh -c "
+        if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
+          set -x
+        fi
+        php -v | grep '^PHP';
+        if [ ${PHP_XDEBUG_ON} -eq 0 ]; then
+          XDEBUG_MODE=\"off\" \
+          .Build/vendor/bin/phpunit -c .Build/public/typo3conf/ext/tea/Build/phpunit/FunctionalTests.xml ${EXTRA_TEST_OPTIONS} --exclude-group not-sqlite ${TEST_FILE};
+        else
+          XDEBUG_MODE=\"${USED_XDEBUG_MODES}\" \
+          XDEBUG_TRIGGER=\"foo\" \
+          XDEBUG_CONFIG=\"client_port=${PHP_XDEBUG_PORT} client_host=host.docker.internal\" \
+          .Build/vendor/bin/phpunit -c .Build/public/typo3conf/ext/tea/Build/phpunit/FunctionalTests.xml ${EXTRA_TEST_OPTIONS} --exclude-group not-sqlite ${TEST_FILE};
+        fi
+      "
+
+  functional_postgres:
+    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    user: "${HOST_UID}"
+    links:
+      - postgres
+    volumes:
+      - ${ROOT_DIR}:${ROOT_DIR}
+    environment:
+      typo3DatabaseDriver: pdo_pgsql
+      typo3DatabaseName: bamboo
+      typo3DatabaseUsername: funcu
+      typo3DatabaseHost: postgres
+      typo3DatabasePassword: funcp
+      COMPOSER_HOME: ".cache/composer-home"
+      COMPOSER_CACHE_DIR: ".cache/composer"
+    working_dir: ${ROOT_DIR}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    command: >
+      /bin/sh -c "
+        if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
+          set -x
+        fi
+        echo Waiting for database start...;
+        while ! nc -z postgres 5432; do
+          sleep 1;
+        done;
+        echo Database is up;
+        php -v | grep '^PHP';
+        if [ ${PHP_XDEBUG_ON} -eq 0 ]; then
+          XDEBUG_MODE=\"off\" \
+          .Build/vendor/bin/phpunit -c .Build/public/typo3conf/ext/tea/Build/phpunit/FunctionalTests.xml ${EXTRA_TEST_OPTIONS} --exclude-group not-postgres ${TEST_FILE};
+        else
+          XDEBUG_MODE=\"${USED_XDEBUG_MODES}\" \
+          XDEBUG_TRIGGER=\"foo\" \
+          XDEBUG_CONFIG=\"client_port=${PHP_XDEBUG_PORT} client_host=host.docker.internal\" \
+          .Build/vendor/bin/phpunit -c .Build/public/typo3conf/ext/tea/Build/phpunit/FunctionalTests.xml ${EXTRA_TEST_OPTIONS} --exclude-group not-postgres ${TEST_FILE};
+        fi
+      "
+
+  functional_mysql:
+    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    user: "${HOST_UID}"
+    links:
+      - mysql
+    volumes:
+      - ${ROOT_DIR}:${ROOT_DIR}
+    environment:
+      typo3DatabaseDriver: "${DATABASE_DRIVER}"
+      typo3DatabaseName: func_test
+      typo3DatabaseUsername: root
+      typo3DatabasePassword: funcp
+      typo3DatabaseHost: mysql
+      COMPOSER_HOME: ".cache/composer-home"
+      COMPOSER_CACHE_DIR: ".cache/composer"
+    working_dir: ${ROOT_DIR}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    command: >
+      /bin/sh -c "
+        if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
+          set -x
+        fi
+        echo Waiting for database start...;
+        while ! nc -z mysql 3306; do
+          sleep 1;
+        done;
+        echo Database is up;
+        php -v | grep '^PHP';
+        if [ ${PHP_XDEBUG_ON} -eq 0 ]; then
+          XDEBUG_MODE=\"off\" \
+          .Build/vendor/bin/phpunit -c .Build/public/typo3conf/ext/tea/Build/phpunit/FunctionalTests.xml ${EXTRA_TEST_OPTIONS} ${TEST_FILE};
+        else
+          XDEBUG_MODE=\"${USED_XDEBUG_MODES}\" \
+          XDEBUG_TRIGGER=\"foo\" \
+          XDEBUG_CONFIG=\"client_port=${PHP_XDEBUG_PORT} client_host=host.docker.internal\" \
+          .Build/vendor/bin/phpunit -c .Build/public/typo3conf/ext/tea/Build/phpunit/FunctionalTests.xml ${EXTRA_TEST_OPTIONS} ${TEST_FILE};
+        fi
+      "
+
+  functional_mariadb:
+    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    user: "${HOST_UID}"
+    links:
+      - mariadb
+    volumes:
+      - ${ROOT_DIR}:${ROOT_DIR}
+    environment:
+      typo3DatabaseDriver: "${DATABASE_DRIVER}"
+      typo3DatabaseName: func_test
+      typo3DatabaseUsername: root
+      typo3DatabasePassword: funcp
+      typo3DatabaseHost: mariadb
+      COMPOSER_HOME: ".cache/composer-home"
+      COMPOSER_CACHE_DIR: ".cache/composer"
+    working_dir: ${ROOT_DIR}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    command: >
+      /bin/sh -c "
+        if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
+          set -x
+        fi
+        echo Waiting for database start...;
+        while ! nc -z mariadb 3306; do
+          sleep 1;
+        done;
+        echo Database is up;
+        php -v | grep '^PHP';
+        if [ ${PHP_XDEBUG_ON} -eq 0 ]; then
+          XDEBUG_MODE=\"off\" \
+          .Build/vendor/bin/phpunit -c .Build/public/typo3conf/ext/tea/Build/phpunit/FunctionalTests.xml ${EXTRA_TEST_OPTIONS} ${TEST_FILE};
+        else
+          XDEBUG_MODE=\"${USED_XDEBUG_MODES}\" \
+          XDEBUG_TRIGGER=\"foo\" \
+          XDEBUG_CONFIG=\"client_port=${PHP_XDEBUG_PORT} client_host=host.docker.internal\" \
+          .Build/vendor/bin/phpunit -c .Build/public/typo3conf/ext/tea/Build/phpunit/FunctionalTests.xml ${EXTRA_TEST_OPTIONS} ${TEST_FILE};
+        fi
+      "
+
+  #---------------------------------------------------------------------------------------------------------------------
+  # code quality tools
+  #---------------------------------------------------------------------------------------------------------------------
+  cgl:
+    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    user: "${HOST_UID}"
+    volumes:
+      - ${ROOT_DIR}:${ROOT_DIR}
+    working_dir: ${ROOT_DIR}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    environment:
+      COMPOSER_HOME: ".cache/composer-home"
+      COMPOSER_CACHE_DIR: ".cache/composer"
+    command: >
+      /bin/sh -c "
+        if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
+          set -x
+        fi
+        php -v | grep '^PHP';
+        if [ ${PHP_XDEBUG_ON} -eq 0 ]; then
+          php -dxdebug.mode=off \
+            .Build/vendor/bin/php-cs-fixer fix \
+              -v \
+              ${CGLCHECK_DRY_RUN} \
+              --config=.php-cs-fixer.php \
+              --using-cache=no .
+        else
+          XDEBUG_MODE=\"debug,develop\" \
+          XDEBUG_TRIGGER=\"foo\" \
+          XDEBUG_CONFIG=\"client_port=${PHP_XDEBUG_PORT} client_host=host.docker.internal\" \
+          PHP_CS_FIXER_ALLOW_XDEBUG=1 \
+          .Build/vendor/bin/php-cs-fixer fix \
+            -v \
+            ${CGLCHECK_DRY_RUN} \
+            --config=.php-cs-fixer.php \
+            --using-cache=no .
+        fi
+      "
+
+  coveralls:
+    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    user: "${HOST_UID}"
+    volumes:
+      - ${ROOT_DIR}:${ROOT_DIR}
+    working_dir: ${ROOT_DIR}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    environment:
+      COMPOSER_HOME: ".cache/composer-home"
+      COMPOSER_CACHE_DIR: ".cache/composer"
+    command: >
+      /bin/sh -c "
+        if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
+          set -x
+        fi
+        php -v | grep '^PHP';
+        php -dxdebug.mode=off .Build/vendor/bin/php-coveralls --coverage_clover=./.Build/logs/clover.xml --json_path=./.Build/logs/coveralls-upload.json -v
+      "
+
+  phpstan:
+    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    user: "${HOST_UID}"
+    volumes:
+      - ${ROOT_DIR}:${ROOT_DIR}
+    working_dir: ${ROOT_DIR}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    environment:
+      COMPOSER_HOME: ".cache/composer-home"
+      COMPOSER_CACHE_DIR: ".cache/composer"
+    command: >
+      /bin/sh -c "
+        if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
+          set -x
+        fi
+        mkdir -p .cache
+        php -dxdebug.mode=off .Build/vendor/bin/phpstan analyze -c ./phpstan.neon --no-progress
+      "
+
+  phpstan_generate_baseline:
+    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    user: "${HOST_UID}"
+    volumes:
+      - ${ROOT_DIR}:${ROOT_DIR}
+    working_dir: ${ROOT_DIR}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    environment:
+      COMPOSER_HOME: ".cache/composer-home"
+      COMPOSER_CACHE_DIR: ".cache/composer"
+    command: >
+      /bin/sh -c "
+        if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
+          set -x
+        fi
+        mkdir -p .cache
+        php -dxdebug.mode=off .Build/vendor/bin/phpstan analyze -c ./phpstan.neon --generate-baseline=./phpstan-baseline.neon --allow-empty-baseline
+      "

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,13 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## x.y.z
 
 ### Added
+- Add `Build/Scripts/runTests.sh` (#634)
 - Add support for TYPO3 v12 (#637)
 
 ### Changed
+- Migrated GitHub Action workflows to use `Build/Scripts/runTests.sh` (#634)
+- Changed forks for 3rd party dev dependencies to allow installation with core v12 (#634)
+- Raised v11 core version to min 11.5.4 to solve issues during min version tests (#634)
 - Upgrade to the testing framework v7 (#629)
 - Make the TCA ready for TYPO3 v12 (#625)
 - Upgrade to PHPUnit 9 and PHPCOV 8 (#610)

--- a/Documentation/Running.rst
+++ b/Documentation/Running.rst
@@ -232,7 +232,7 @@ settings so this configuration can serve as a template:
 
 -  Directory: use the `Tests/Unit` directory in your project.
 -  (*) Use alternative configuration file.
--  Use `.Build/vendor/typo3/testing-framework/Resources/Core/Build/UnitTests.xml`
+-  Use `.Build/public/typo3conf/tea/Build/phpunit/UnitTests.xml`
    in your project folder.
 -  Add the following environment variables:
 
@@ -258,4 +258,4 @@ settings:
 -  Directory: use the `Tests/Functional` directory in your project.
 -  (*) Use alternative configuration file.
 -  Use
-   `.Build/vendor/typo3/testing-framework/Resources/Core/Build/FunctionalTests.xml`.
+   `.Build/public/typo3conf/tea/Build/phpunit/FunctionalTests.xml`.

--- a/composer.json
+++ b/composer.json
@@ -127,7 +127,7 @@
 		],
 		"ci:coverage:merge": [
 			"@coverage:create-directories",
-			"@php tools/phpcov merge --clover=./build/logs/clover.xml ./.Build/coverage/"
+			"@php tools/phpcov merge --clover=./.Build/logs/clover.xml ./.Build/coverage/"
 		],
 		"ci:coverage:unit": [
 			"@coverage:create-directories",
@@ -168,7 +168,7 @@
 		"ci:tests:unit": ".Build/vendor/bin/phpunit -c .Build/vendor/typo3/testing-framework/Resources/Core/Build/UnitTests.xml Tests/Unit",
 		"ci:ts:lint": "typoscript-lint -c Configuration/TsLint.yml --ansi -n --fail-on-warnings -vvv Configuration/TypoScript",
 		"ci:yaml:lint": "find . ! -path '*.Build/*' ! -path '*node_modules/*' -regextype egrep -regex '.*.ya?ml$' | xargs -r php ./.Build/vendor/bin/yaml-lint",
-		"coverage:create-directories": "mkdir -p build/logs .Build/coverage",
+		"coverage:create-directories": "mkdir -p .Build/logs .Build/coverage",
 		"docs:generate": [
 			"docker run --rm t3docs/render-documentation show-shell-commands > tempfile.sh; echo 'dockrun_t3rd makehtml' >> tempfile.sh; bash tempfile.sh; rm tempfile.sh"
 		],

--- a/composer.json
+++ b/composer.json
@@ -123,7 +123,7 @@
 		],
 		"ci:coverage:functional": [
 			"@coverage:create-directories",
-			".Build/vendor/bin/phpunit -c .Build/vendor/typo3/testing-framework/Resources/Core/Build/FunctionalTests.xml --whitelist Classes --coverage-php=.Build/coverage/functional.cov Tests/Functional"
+			".Build/vendor/bin/phpunit -c .Build/public/typo3conf/ext/tea/Build/phpunit/FunctionalTests.xml --whitelist Classes --coverage-php=.Build/coverage/functional.cov Tests/Functional"
 		],
 		"ci:coverage:merge": [
 			"@coverage:create-directories",
@@ -131,7 +131,7 @@
 		],
 		"ci:coverage:unit": [
 			"@coverage:create-directories",
-			".Build/vendor/bin/phpunit -c .Build/vendor/typo3/testing-framework/Resources/Core/Build/UnitTests.xml --whitelist Classes --coverage-php=.Build/coverage/unit.cov Tests/Unit"
+			".Build/vendor/bin/phpunit -c .Build/public/typo3conf/ext/tea/Build/phpunit/UnitTests.xml --whitelist Classes --coverage-php=.Build/coverage/unit.cov Tests/Unit"
 		],
 		"ci:dynamic": [
 			"@ci:tests"
@@ -164,8 +164,8 @@
 			"@ci:tests:unit",
 			"@ci:tests:functional"
 		],
-		"ci:tests:functional": "find 'Tests/Functional' -wholename '*Test.php' | parallel --gnu 'echo; echo \"Running functional test suite {}\"; .Build/vendor/bin/phpunit -c .Build/vendor/typo3/testing-framework/Resources/Core/Build/FunctionalTests.xml {}';",
-		"ci:tests:unit": ".Build/vendor/bin/phpunit -c .Build/vendor/typo3/testing-framework/Resources/Core/Build/UnitTests.xml Tests/Unit",
+		"ci:tests:functional": "find 'Tests/Functional' -wholename '*Test.php' | parallel --gnu 'echo; echo \"Running functional test suite {}\"; .Build/vendor/bin/phpunit -c .Build/public/typo3conf/ext/tea/Build/phpunit/FunctionalTests.xml {}';",
+		"ci:tests:unit": ".Build/vendor/bin/phpunit -c .Build/public/typo3conf/ext/tea/Build/phpunit/UnitTests.xml Tests/Unit",
 		"ci:ts:lint": "typoscript-lint -c Configuration/TsLint.yml --ansi -n --fail-on-warnings -vvv Configuration/TypoScript",
 		"ci:yaml:lint": "find . ! -path '*.Build/*' ! -path '*node_modules/*' -regextype egrep -regex '.*.ya?ml$' | xargs -r php ./.Build/vendor/bin/yaml-lint",
 		"coverage:create-directories": "mkdir -p .Build/logs .Build/coverage",

--- a/composer.json
+++ b/composer.json
@@ -29,16 +29,16 @@
 	"require": {
 		"php": "~7.4.0 || ~8.0.0 || ~8.1.0",
 		"psr/http-message": "^1.0.1",
-		"typo3/cms-core": "^11.5.2 || ^12.0",
-		"typo3/cms-extbase": "^11.5.2 || ^12.0",
-		"typo3/cms-fluid": "^11.5.2 || ^12.0",
-		"typo3/cms-frontend": "^11.5.2 || ^12.0"
+		"typo3/cms-core": "^11.5.4 || ^12.0",
+		"typo3/cms-extbase": "^11.5.4 || ^12.0",
+		"typo3/cms-fluid": "^11.5.4 || ^12.0",
+		"typo3/cms-frontend": "^11.5.4 || ^12.0"
 	},
 	"require-dev": {
 		"doctrine/dbal": "^2.13.8 || ^3.3.7",
 		"ergebnis/composer-normalize": "^2.28.3",
 		"friendsofphp/php-cs-fixer": "^3.12.0",
-		"helmich/typo3-typoscript-lint": "^2.5.2",
+		"helmich/typo3-typoscript-lint": "lwolf-php81-support-dev",
 		"jangregor/phpstan-prophecy": "^1.0.0",
 		"php-coveralls/php-coveralls": "^2.5.3",
 		"phpspec/prophecy": "^1.15.0",
@@ -48,12 +48,12 @@
 		"phpstan/phpstan-phpunit": "^1.1.1",
 		"phpstan/phpstan-strict-rules": "^1.4.4",
 		"phpunit/phpunit": "^9.5.25",
-		"saschaegerer/phpstan-typo3": "^1.1.2",
+		"saschaegerer/phpstan-typo3": "12.0.x-dev",
 		"sbuerk/typo3-cmscomposerinstallers-testingframework-bridge": "^0.0.1",
 		"seld/jsonlint": "^1.9.0",
 		"squizlabs/php_codesniffer": "^3.7.1",
 		"symfony/yaml": "^5.4 || ^6.1",
-		"typo3/cms-fluid-styled-content": "^11.5.2 || ^12.0",
+		"typo3/cms-fluid-styled-content": "^11.5.4 || ^12.0",
 		"typo3/coding-standards": "^0.5.5",
 		"typo3/testing-framework": "^7.0@dev"
 	},
@@ -63,6 +63,17 @@
 	"conflict": {
 		"typo3/class-alias-loader": "< 1.1.0"
 	},
+	"repositories": {
+		"1_phpstan-typo3_fork": {
+			"type": "vcs",
+			"url": "https://github.com/linawolf/phpstan-typo3.git"
+		},
+		"2_typo3-typoscript-lint_fork": {
+			"type": "vcs",
+			"url": "https://github.com/linawolf/typo3-typoscript-lint.git"
+		}
+	},
+	"minimum-stability": "dev",
 	"prefer-stable": true,
 	"autoload": {
 		"psr-4": {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,2 +1,2 @@
 parameters:
-	ignoreErrors:
+	ignoreErrors: []


### PR DESCRIPTION
# :dart:  Mission

This pull-request consists of multiple commits, working towards multi core testing, testing with runTests.sh and streamlining stuff during the working path. 

Will note only the big players here in the pull-request - descriptions are for the pull-request, and are not copy&pasted from the commit messages. So check them on it's own.

Resolve #533
Resolve #635
Resolve #94
Resolve #534

# :warning: **Documentation not included.**
This should be updated in a dedicated pull-request, to avoid blocking & working against each other if this won't be merged soon.

# :information_source: Enhancements

This pull-request contains mainly TYPO3 v11 and v12 testing (unit/functional) with multiple php versions and against multiple dbmns, drivers and dbmns-versions

# Short TODO list

- [x] Mitigate folder conflict on case-insensitive filesystems
- [x] Introduce basic `Build/Scripts/runTests.sh`
- [x] Resolve v12 dependency conflicts (introduced due merged https://github.com/TYPO3-Documentation/tea/commit/639e41451212ee8b92c0bdf1a927068e25f2ced2)
- [x] Verify coverage with runTests.sh unit/functional tests
- [x] Coveralls upload (seems to be broken in corresponding workflow)
- [x] Update changelog file to add all containing changes
- [x] Rebase before making pull-request public (also in-between)

# :bell: Notable commits

#### [[TASK] Add .gitignore for JetBrains Fleet editor](https://github.com/TYPO3-Documentation/tea/pull/634/commits/8bb1b55ca7bb2d040230bf11d5ecb41b1556d580)

Add ignore for new JetBrains Fleet Editor configuration folder to avoid
unintended committing of these files to the repository.

#### [[BUGFIX] Raise typo3/cms-* to 11.5.4 to be stable with minimum deps](https://github.com/TYPO3-Documentation/tea/pull/634/commits/da693e40b753236aa085f408ff04c130319c881e)

Raises minimum core version slightly to avoid incompatibility with 3rd party
components and PHP8.1 in functional tests.  Beside this, we need at least
this version as core ships with QueryBuilder forward combat methods 
`executeQuery()` and `executeStatement()` only since this version.

See: https://review.typo3.org/c/Packages/TYPO3.CMS/+/72430

Additional some dev dependencies are changed to avoid conflicts
with recently added core v11/v12 support (root compoer conflicts).
This requires to add (temporarly) two forks as repositories until
fixes are merged and released.

#### [[TASK] Avoid race condition on case-insensitive filesystems](https://github.com/TYPO3-Documentation/tea/pull/634/commits/1e8b85e8589fc635e815fc627e20a7f650288cbf)

This change basicly reconfigure phpcoverall to avoid conflicts with `build/` and `Build/`
folders in case-insensitive filesystems like MacOS default partition. Needed as preparation
to introduce TYPO3 core `Build/` structure like `runTests.sh`.

#### [[TASK] Avoid using testing-framework boilerplate files](https://github.com/TYPO3-Documentation/tea/pull/634/commits/41b44c28a4d06f01e3ff788e98ea9948fe16f64a)

Basicly clone and streamline testinf-framework configs and move it
to the extension. For detailed explanation see commit message.

#### [[TASK] Introduce Build/Scripts/runTests.sh adoption](https://github.com/TYPO3-Documentation/tea/pull/634/commits/71bc7e137d7877d74b9b9e4dff7813be0779e85f)

This change introduces the well-known `Build/Scripts/runTests.sh` from TYPO3 core
development and related extensions and repository maintained by core-developers.
Repository needs are adopted to make all available calls callable and doable through
the `runTests.sh` wrapper.

Introducing this wrapper make it simple to test (functional) against multiple database
systems and versions, different php versions and also core versions (in the future) easily
over all systems and CI's (GitHub Actions, Gitlab, Linux, MacOSx, Windows WSL2, ...)
without the need of proper setup of all tools and services on the host system beforehand.

Not included is the exchange in CI definition which will be done in a dedicated
follow-up change or changes.

#### [[TASK] Migrate GitHub Actions to use Build/Scripts/runTests.sh](https://github.com/TYPO3-Documentation/tea/pull/634/commits/d0282d488a7e2d40590559d268051ec6b43b4898)

This change migrates GitHub Action workflows to use `runTests.sh`

#### [[TASK] Update CHANGELOG.md](https://github.com/TYPO3-Documentation/tea/pull/634/commits/76fae8c84b809d671997c7d1bc919cedc304a004)

Add changed to CHANGELOG.md.

#### [[TASK] Coveralls upload play-a-round due decline error messages](https://github.com/TYPO3-Documentation/tea/pull/634/commits/a1f39aa02c66a41d5096a15c8d1eb5fc6f10e48a)

Coveralls upload reverted to direct php / composer installation. Coveralls upload
should be re-evaluated dedicated. Eventually it was because of the fast and multiple
force-pushes on the same pull-request.