### PR TITLE
[FEATURE] Integrate `runTests.sh` execution wrapper - round one

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,6 +10,7 @@
 /.php-cs-fixer.php export-ignore
 /.phpstorm.meta.php export-ignore
 /.prettierrc.js export-ignore
+/Build/ export-ignore
 /Tests/ export-ignore
 /package.json export-ignore
 /phive.xml export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,13 @@
 /*.idea
 /.Build/*
+/.cache
 /.fleet
 /.php-cs-fixer.cache
 /.phpunit.result.cache
 /Documentation-GENERATED-temp/
 /clover.xml
 /composer.lock
+/generate-documentation.sh
 /nbproject
 /node_modules/
 /package-lock.json

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -1,0 +1,645 @@
+#!/usr/bin/env bash
+
+#
+# TYPO3 core test runner based on docker.
+#
+
+waitFor() {
+    local HOST=${1}
+    local PORT=${2}
+    local TESTCOMMAND="
+        COUNT=0;
+        while ! nc -z ${HOST} ${PORT}; do
+            if [ \"\${COUNT}\" -gt 10 ]; then
+              echo \"Can not connect to ${HOST} port ${PORT}. Aborting.\";
+              exit 1;
+            fi;
+            sleep 1;
+            COUNT=\$((COUNT + 1));
+        done;
+    "
+    ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name wait-for-${SUFFIX} ${XDEBUG_MODE} -e XDEBUG_CONFIG="${XDEBUG_CONFIG}" ${IMAGE_ALPINE} /bin/sh -c "${TESTCOMMAND}"
+}
+
+cleanUp() {
+    ATTACHED_CONTAINERS=$(${CONTAINER_BIN} ps --filter network=${NETWORK} --format='{{.Names}}')
+    for ATTACHED_CONTAINER in ${ATTACHED_CONTAINERS}; do
+        ${CONTAINER_BIN} rm -f ${ATTACHED_CONTAINER} >/dev/null
+    done
+    ${CONTAINER_BIN} network rm ${NETWORK} >/dev/null
+}
+
+# Options -a and -d depend on each other. The function
+# validates input combinations and sets defaults.
+handleDbmsAndDriverOptions() {
+    case ${DBMS} in
+        mariadb)
+            [ -z "${DATABASE_DRIVER}" ] && DATABASE_DRIVER="mysqli"
+            if [ "${DATABASE_DRIVER}" != "mysqli" ] && [ "${DATABASE_DRIVER}" != "pdo_mysql" ]; then
+                echo "Invalid option -a ${DATABASE_DRIVER} with -d ${DBMS}" >&2
+                echo >&2
+                echo "call \".Build/Scripts/runTests.sh -h\" to display help and valid options" >&2
+                exit 1
+            fi
+            ;;
+        mysql)
+            [ -z "${DATABASE_DRIVER}" ] && DATABASE_DRIVER="mysqli"
+            if [ "${DATABASE_DRIVER}" != "mysqli" ] && [ "${DATABASE_DRIVER}" != "pdo_mysql" ]; then
+                echo "Invalid option -a ${DATABASE_DRIVER} with -d ${DBMS}" >&2
+                echo >&2
+                echo "call \".Build/Scripts/runTests.sh -h\" to display help and valid options" >&2
+                exit 1
+            fi
+            ;;
+        postgres)
+            if [ -n "${DATABASE_DRIVER}" ]; then
+                echo "Invalid option -a ${DATABASE_DRIVER} with -d ${DBMS}" >&2
+                echo >&2
+                echo "call \".Build/Scripts/runTests.sh -h\" to display help and valid options" >&2
+                exit 1
+            fi
+            ;;
+        sqlite)
+            if [ -n "${DATABASE_DRIVER}" ]; then
+                echo "Invalid option -a ${DATABASE_DRIVER} with -d ${DBMS}" >&2
+                echo >&2
+                echo "call \".Build/Scripts/runTests.sh -h\" to display help and valid options" >&2
+                exit 1
+            fi
+            ;;
+        *)
+            echo "Invalid option -d ${DBMS}" >&2
+            echo >&2
+            echo "call \".Build/Scripts/runTests.sh -h\" to display help and valid options" >&2
+            exit 1
+            ;;
+    esac
+}
+
+cleanCacheFiles() {
+    echo -n "Clean caches ... "
+    rm -rf \
+        .Build/.cache \
+        .php-cs-fixer.cache
+    echo "done"
+}
+
+cleanTestFiles() {
+    # test related
+    echo -n "Clean test related files ... "
+    rm -rf \
+        .Build/Web/typo3temp/var/tests/
+    echo "done"
+}
+
+cleanRenderedDocumentationFiles() {
+    echo -n "Clean rendered documentation files ... "
+    rm -rf \
+        Documentation-GENERATED-temp
+    echo "done"
+}
+
+loadHelp() {
+    # Load help text into $HELP
+    read -r -d '' HELP <<EOF
+TYPO3 core test runner. Execute acceptance, unit, functional and other test suites in
+a container based test environment. Handles execution of single test files, sending
+xdebug information to a local IDE and more.
+
+Usage: $0 [options] [file]
+
+Options:
+    -s <...>
+        Specifies which test suite to run
+            - cgl: Checks the code style with the PHP Coding Standards Fixer (PHP-CS-Fixer).
+            - cglFix: Fixes the code style with PHP-CS-Fixer."
+            - clean: clean up build, cache and testing related files and folders
+            - cleanCache: clean up cache related files and folders
+            - cleanRenderedDocumentation: clean up rendered documentation files and folders (Documentation-GENERATED-temp)
+            - cleanTests: clean up test related files and folders
+            - composer: "composer" with all remaining arguments dispatched.
+            - composerInstallMax: "composer update", with no platform.php config.
+            - composerInstallMin: "composer update --prefer-lowest", with platform.php set to PHP version x.x.0.
+            - docsGenerate: Renders the extension ReST documentation.
+            - functional: PHP functional tests
+            - lintTypoScript: TypoScript linting
+            - lintPhp: PHP linting
+            - lintJson: JSON linting
+            - lintYaml: YAML linting
+            - phpstan: phpstan tests
+            - phpstanGenerateBaseline: regenerate phpstan baseline, handy after phpstan updates
+            - unit (default): PHP unit tests
+            - unitRandom: PHP unit tests in random order, add -o <number> to use specific seed
+
+    -a <mysqli|pdo_mysql>
+        Only with -s functional|functionalDeprecated
+        Specifies to use another driver, following combinations are available:
+            - mysql
+                - mysqli (default)
+                - pdo_mysql
+            - mariadb
+                - mysqli (default)
+                - pdo_mysql
+
+    -d <sqlite|mariadb|mysql|postgres>
+        Only with -s functional|functionalDeprecated|acceptance|acceptanceInstall
+        Specifies on which DBMS tests are performed
+            - sqlite: (default): use sqlite
+            - mariadb: use mariadb
+            - mysql: use MySQL
+            - postgres: use postgres
+
+    -i <10.3|10.4|10.5|10.6|10.7|10.8|10.9|10.10|10.11|11.0|11.1>
+        Only with -d mariadb
+        Specifies on which version of mariadb tests are performed
+            - 10.3   short-term, maintained until 2023-05-25 (default)
+            - 10.4   short-term, maintained until 2024-06-18
+            - 10.5   short-term, maintained until 2025-06-24
+            - 10.6   long-term, maintained until 2026-06
+            - 10.7   short-term, no longer maintained
+            - 10.8   short-term, maintained until 2023-05
+            - 10.9   short-term, maintained until 2023-08
+            - 10.10  short-term, maintained until 2023-11
+            - 10.11  long-term, maintained until 2028-02
+            - 11.0   development series
+            - 11.1   short-term development series
+
+    -j <5.5|5.6|5.7|8.0>
+        Only with -d mysql
+        Specifies on which version of mysql tests are performed
+            - 5.5   unmaintained since 2018-12
+            - 5.6   unmaintained since 2021-02
+            - 5.7   maintained until 2023-10
+            - 8.0   maintained until 2026-04 (default)
+
+    -k <10|11|12|13|14|15>
+        Only with -d postgres
+        Specifies on which version of postgres tests are performed
+            - 10    unmaintained since 2022-11-10 (default)
+            - 11    maintained until 2023-11-09
+            - 12    maintained until 2024-11-14
+            - 13    maintained until 2025-11-13
+            - 14    maintained until 2026-11-12
+            - 15    maintained until 2027-11-11
+
+    -t <11.5|12.4>
+        Only with -s composerInstall|composerInstallMin|composerInstallMax
+        Specifies the TYPO3 CORE Version to be used
+            - 11: (default) use TYPO3 v11 with typo3/cms-composer-installers ^3
+            - 12: use TYPO3 v12 with typo3/cms-composer-installers ^5
+
+    -p <7.4|8.0|8.1|8.2>
+        Specifies the PHP minor version to be used
+            - 7.4: use PHP 7.4
+            - 8.0: use PHP 8.0
+            - 8.1: (default) use PHP 8.1
+            - 8.2: use PHP 8.2
+
+    -e "<phpunit options>"
+        Only with -s functional|functionalDeprecated|unit|unitDeprecated|unitRandom|acceptance
+        Additional options to send to phpunit (unit & functional tests) or codeception (acceptance
+        tests). For phpunit, options starting with "--" must be added after options starting with "-".
+        Example -e "-v --filter canRetrieveValueWithGP" to enable verbose output AND filter tests
+        named "canRetrieveValueWithGP"
+
+    -x
+        Only with -s functional|functionalDeprecated|unit|unitDeprecated|unitRandom|acceptance|acceptanceInstall
+        Send information to host instance for test or system under test break points. This is especially
+        useful if a local PhpStorm instance is listening on default xdebug port 9003. A different port
+        can be selected with -y
+
+    -y <port>
+        Send xdebug information to a different port than default 9003 if an IDE like PhpStorm
+        is not listening on default port.
+
+    -o <number>
+        Only with -s unitRandom
+        Set specific random seed to replay a random run in this order again. The phpunit randomizer
+        outputs the used seed at the end (in gitlab core testing logs, too). Use that number to
+        replay the unit tests in that order.
+
+    -n
+        Only with -s cgl|composerNormalize
+        Activate dry-run in CGL check that does not actively change files and only prints broken ones.
+
+    -u
+        Update existing typo3/core-testing-*:latest container images and remove dangling local volumes.
+        New images are published once in a while and only the latest ones are supported by core testing.
+        Use this if weird test errors occur. Also removes obsolete image versions of typo3/core-testing-*.
+
+    -h
+        Show this help.
+
+Examples:
+    # Run all core unit tests using PHP 8.1
+    ./Build/Scripts/runTests.sh
+    ./Build/Scripts/runTests.sh -s unit
+
+    # Run all core units tests and enable xdebug (have a PhpStorm listening on port 9003!)
+    ./Build/Scripts/runTests.sh -x
+
+    # Run unit tests in phpunit verbose mode with xdebug on PHP 8.1 and filter for test canRetrieveValueWithGP
+    ./Build/Scripts/runTests.sh -x -p 8.1 -e "-v --filter canRetrieveValueWithGP"
+
+    # Run functional tests in phpunit with a filtered test method name in a specified file
+    # example will currently execute two tests, both of which start with the search term
+    ./Build/Scripts/runTests.sh -s functional -e "--filter deleteContent" typo3/sysext/core/Tests/Functional/DataHandling/Regular/Modify/ActionTest.php
+
+    # Run functional tests on postgres with xdebug, php 8.1 and execute a restricted set of tests
+    ./Build/Scripts/runTests.sh -x -p 8.1 -s functional -d postgres typo3/sysext/core/Tests/Functional/Authentication
+
+    # Run functional tests on postgres 11
+    ./Build/Scripts/runTests.sh -s functional -d postgres -k 11
+
+    # Run restricted set of application acceptance tests
+    ./Build/Scripts/runTests.sh -s acceptance typo3/sysext/core/Tests/Acceptance/Application/Login/BackendLoginCest.php:loginButtonMouseOver
+
+    # Run installer tests of a new instance on sqlite
+    ./Build/Scripts/runTests.sh -s acceptanceInstall -d sqlite
+EOF
+}
+
+# Test if docker exists, else exit out with error
+if ! type "docker" >/dev/null; then
+    echo "This script relies on docker. Please install" >&2
+    exit 1
+fi
+
+# Option defaults
+TEST_SUITE="unit"
+CORE_VERSION="11.5"
+DBMS="sqlite"
+PHP_VERSION="8.1"
+PHP_XDEBUG_ON=0
+PHP_XDEBUG_PORT=9003
+EXTRA_TEST_OPTIONS=""
+PHPUNIT_RANDOM=""
+CGLCHECK_DRY_RUN=0
+DATABASE_DRIVER=""
+MARIADB_VERSION="10.3"
+MYSQL_VERSION="8.0"
+POSTGRES_VERSION="10"
+CONTAINER_BIN="docker"
+
+# Option parsing updates above default vars
+# Reset in case getopts has been used previously in the shell
+OPTIND=1
+# Array for invalid options
+INVALID_OPTIONS=()
+# Simple option parsing based on getopts (! not getopt)
+while getopts "a:s:d:i:j:k:p:e:t:xy:o:nhu" OPT; do
+    case ${OPT} in
+        s)
+            TEST_SUITE=${OPTARG}
+            ;;
+        a)
+            DATABASE_DRIVER=${OPTARG}
+            ;;
+        d)
+            DBMS=${OPTARG}
+            ;;
+        i)
+            MARIADB_VERSION=${OPTARG}
+            if ! [[ ${MARIADB_VERSION} =~ ^(10.3|10.4|10.5|10.6|10.7|10.8|10.9|10.10|10.11|11.0|11.1)$ ]]; then
+                INVALID_OPTIONS+=("i ${OPTARG}")
+            fi
+            ;;
+        j)
+            MYSQL_VERSION=${OPTARG}
+            if ! [[ ${MYSQL_VERSION} =~ ^(5.5|5.6|5.7|8.0)$ ]]; then
+                INVALID_OPTIONS+=("j ${OPTARG}")
+            fi
+            ;;
+        k)
+            POSTGRES_VERSION=${OPTARG}
+            if ! [[ ${POSTGRES_VERSION} =~ ^(10|11|12|13|14|15)$ ]]; then
+                INVALID_OPTIONS+=("${OPTARG}")
+            fi
+            ;;
+        p)
+            PHP_VERSION=${OPTARG}
+            if ! [[ ${PHP_VERSION} =~ ^(7.4|8.0|8.1|8.2|8.3)$ ]]; then
+                INVALID_OPTIONS+=("p ${OPTARG}")
+            fi
+            ;;
+        e)
+            EXTRA_TEST_OPTIONS=${OPTARG}
+            ;;
+        t)
+            CORE_VERSION=${OPTARG}
+            if ! [[ ${CORE_VERSION} =~ ^(11.5|12.4)$ ]]; then
+                INVALID_OPTIONS+=("t ${OPTARG}")
+            fi
+            ;;
+        x)
+            PHP_XDEBUG_ON=1
+            ;;
+        y)
+            PHP_XDEBUG_PORT=${OPTARG}
+            ;;
+        o)
+            PHPUNIT_RANDOM="--random-order-seed=${OPTARG}"
+            ;;
+        n)
+            CGLCHECK_DRY_RUN=1
+            ;;
+        h)
+            loadHelp
+            echo "${HELP}"
+            exit 0
+            ;;
+        u)
+            TEST_SUITE=update
+            ;;
+        \?)
+            INVALID_OPTIONS+=("${OPTARG}")
+            ;;
+        :)
+            INVALID_OPTIONS+=("${OPTARG}")
+            ;;
+    esac
+done
+
+# Exit on invalid options
+if [ ${#INVALID_OPTIONS[@]} -ne 0 ]; then
+    echo "Invalid option(s):" >&2
+    for I in "${INVALID_OPTIONS[@]}"; do
+        echo "-"${I} >&2
+    done
+    echo >&2
+    echo "call \".Build/Scripts/runTests.sh -h\" to display help and valid options"
+    exit 1
+fi
+
+COMPOSER_ROOT_VERSION="3.0.x-dev"
+HOST_UID=$(id -u)
+USERSET=""
+if [ $(uname) != "Darwin" ]; then
+    USERSET="--user $HOST_UID"
+fi
+
+# Go to the directory this script is located, so everything else is relative
+# to this dir, no matter from where this script is called, then go up two dirs.
+THIS_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
+cd "$THIS_SCRIPT_DIR" || exit 1
+cd ../../ || exit 1
+ROOT_DIR="${PWD}"
+
+# Create .cache dir: composer need this.
+mkdir -p .cache
+mkdir -p .Build/Web/typo3temp/var/tests
+
+PHPSTAN_CONFIG_FILE="phpstan.neon"
+IMAGE_PREFIX="docker.io/"
+# Non-CI fetches TYPO3 images (php and nodejs) from ghcr.io
+TYPO3_IMAGE_PREFIX="ghcr.io/"
+CONTAINER_INTERACTIVE="-it --init"
+
+IS_CORE_CI=0
+# ENV var "CI" is set by gitlab-ci. We use it here to distinct 'local' and 'CI' environment.
+if [ "${CI}" == "true" ]; then
+    IS_CORE_CI=1
+    # In CI, we need to pull images from docker.io for the registry proxy to kick in.
+    TYPO3_IMAGE_PREFIX="docker.io/"
+    IMAGE_PREFIX=""
+    CONTAINER_INTERACTIVE=""
+fi
+
+IMAGE_PHP="${TYPO3_IMAGE_PREFIX}typo3/core-testing-$(echo "php${PHP_VERSION}" | sed -e 's/\.//'):latest"
+IMAGE_ALPINE="${IMAGE_PREFIX}alpine:3.8"
+IMAGE_DOCS="ghcr.io/t3docs/render-documentation:latest"
+IMAGE_SELENIUM="${IMAGE_PREFIX}selenium/standalone-chrome:4.0.0-20211102"
+IMAGE_MARIADB="${IMAGE_PREFIX}mariadb:${MARIADB_VERSION}"
+IMAGE_MYSQL="${IMAGE_PREFIX}mysql:${MYSQL_VERSION}"
+IMAGE_POSTGRES="${IMAGE_PREFIX}postgres:${POSTGRES_VERSION}-alpine"
+
+# Detect arm64 and use a seleniarm image.
+# In a perfect world selenium would have a arm64 integrated, but that is not on the horizon.
+# So for the time being we have to use seleniarm image.
+ARCH=$(uname -m)
+if [ ${ARCH} = "arm64" ]; then
+    IMAGE_SELENIUM="${IMAGE_PREFIX}seleniarm/standalone-chromium:4.1.2-20220227"
+    echo "Architecture" ${ARCH} "requires" ${IMAGE_SELENIUM} "to run acceptance tests."
+fi
+
+# Set $1 to first mass argument, this is the optional test file or test directory to execute
+shift $((OPTIND - 1))
+TEST_FILE=${1}
+
+SUFFIX=$(echo $RANDOM)
+NETWORK="friendsoftypo3-tea-${SUFFIX}"
+${CONTAINER_BIN} network create ${NETWORK} >/dev/null
+
+CONTAINER_COMMON_PARAMS="${CONTAINER_INTERACTIVE} --rm --network $NETWORK --add-host "host.docker.internal:host-gateway" $USERSET -v ${ROOT_DIR}:${ROOT_DIR} -w ${ROOT_DIR}"
+CONTAINER_DOCS_PARAMS="${CONTAINER_INTERACTIVE} --rm $USERSET -v ${ROOT_DIR}:/PROJECT -v ${ROOT_DIR}/Documentation-GENERATED-temp:/RESULT -w ${ROOT_DIR}"
+
+if [ ${PHP_XDEBUG_ON} -eq 0 ]; then
+    XDEBUG_MODE="-e XDEBUG_MODE=off"
+    XDEBUG_CONFIG=" "
+else
+    XDEBUG_MODE="-e XDEBUG_MODE=debug -e XDEBUG_TRIGGER=foo"
+    XDEBUG_CONFIG="client_port=${PHP_XDEBUG_PORT} client_host=host.docker.internal"
+fi
+
+# Suite execution
+case ${TEST_SUITE} in
+    cgl)
+        if [ "${CGLCHECK_DRY_RUN}" -eq 1 ]; then
+            COMMAND="composer ci:php:cs-fixer"
+        else
+            COMMAND="composer fix:php:cs"
+        fi
+        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name composer-command-${SUFFIX} -e COMPOSER_CACHE_DIR=.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} /bin/sh -c "${COMMAND}"
+        SUITE_EXIT_CODE=$?
+        ;;
+    clean)
+        cleanCacheFiles
+        cleanRenderedDocumentationFiles
+        cleanTestFiles
+        ;;
+    cleanCache)
+        cleanCacheFiles
+        ;;
+    cleanRenderedDocumentation)
+        cleanRenderedDocumentationFiles
+        ;;
+    cleanTests)
+        cleanTestFiles
+        ;;
+    composer)
+        COMMAND="composer \"$@\""
+        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name composer-command-${SUFFIX} -e COMPOSER_CACHE_DIR=.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} /bin/sh -c "${COMMAND}"
+        SUITE_EXIT_CODE=$?
+        ;;
+    composerInstall)
+        COMMAND="composer install"
+        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name composer-install-${SUFFIX} -e COMPOSER_CACHE_DIR=.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} /bin/sh -c "${COMMAND}"
+        SUITE_EXIT_CODE=$?
+        ;;
+    composerInstallMax)
+        COMMAND="composer config --unset platform.php; composer require --no-ansi --no-interaction --no-progress --no-install typo3/cms-core:"^${CORE_VERSION}"; composer update --no-progress --no-interaction; composer dumpautoload; composer show"
+        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name composer-install-max-${SUFFIX} -e COMPOSER_CACHE_DIR=.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} /bin/sh -c "${COMMAND}"
+        SUITE_EXIT_CODE=$?
+        ;;
+    composerInstallMin)
+        COMMAND="composer config platform.php ${PHP_VERSION}.0; composer require --no-ansi --no-interaction --no-progress --no-install typo3/cms-core:"^${CORE_VERSION}"; composer update --prefer-lowest --no-progress --no-interaction; composer dumpautoload; composer show"
+        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name composer-install-min-${SUFFIX} -e COMPOSER_CACHE_DIR=.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} /bin/sh -c "${COMMAND}"
+        SUITE_EXIT_CODE=$?
+        ;;
+    composerNormalize)
+        COMMAND="composer ci:composer:normalize"
+        if [ "${CGLCHECK_DRY_RUN}" -eq 1 ]; then
+            COMMAND="composer ci:composer:normalize"
+        else
+            COMMAND="composer fix:composer:normalize"
+        fi
+        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name composer-normalize-${SUFFIX} -e COMPOSER_CACHE_DIR=.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_DOCS} /bin/sh -c "${COMMAND}"
+        SUITE_EXIT_CODE=$?
+        ;;
+    docsGenerate)
+        # @todo contact the documentation team for a future rootles podman version
+        ${CONTAINER_BIN} run --rm ${IMAGE_DOCS} show-shell-commands > generate-documentation.sh
+        echo 'dockrun_t3rd makehtml' >> generate-documentation.sh
+        bash generate-documentation.sh
+        rm -Rf generate-documentation.sh
+        SUITE_EXIT_CODE=$?
+        ;;
+    functional)
+        [ -z "${TEST_FILE}" ] && TEST_FILE="Tests/Functional"
+        handleDbmsAndDriverOptions
+        COMMAND=".Build/bin/phpunit -c .Build/vendor/typo3/testing-framework/Resources/Core/Build/FunctionalTests.xml --exclude-group not-${DBMS} ${EXTRA_TEST_OPTIONS} ${TEST_FILE}"
+        case ${DBMS} in
+            mariadb)
+                echo "Using driver: ${DATABASE_DRIVER}"
+                ${CONTAINER_BIN} run --name mariadb-func-${SUFFIX} --network ${NETWORK} -d -e MYSQL_ROOT_PASSWORD=funcp --tmpfs /var/lib/mysql/:rw,noexec,nosuid ${IMAGE_MARIADB} >/dev/null
+                waitFor mariadb-func-${SUFFIX} 3306
+                CONTAINERPARAMS="-e typo3DatabaseDriver=${DATABASE_DRIVER} -e typo3DatabaseName=func_test -e typo3DatabaseUsername=root -e typo3DatabaseHost=mariadb-func-${SUFFIX} -e typo3DatabasePassword=funcp"
+                ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name functional-${SUFFIX} ${XDEBUG_MODE} -e XDEBUG_CONFIG="${XDEBUG_CONFIG}" ${CONTAINERPARAMS} ${IMAGE_PHP} ${COMMAND}
+                SUITE_EXIT_CODE=$?
+                ;;
+            mysql)
+                echo "Using driver: ${DATABASE_DRIVER}"
+                ${CONTAINER_BIN} run --name mysql-func-${SUFFIX} --network ${NETWORK} -d -e MYSQL_ROOT_PASSWORD=funcp --tmpfs /var/lib/mysql/:rw,noexec,nosuid ${IMAGE_MYSQL} >/dev/null
+                waitFor mysql-func-${SUFFIX} 3306
+                CONTAINERPARAMS="-e typo3DatabaseDriver=${DATABASE_DRIVER} -e typo3DatabaseName=func_test -e typo3DatabaseUsername=root -e typo3DatabaseHost=mysql-func-${SUFFIX} -e typo3DatabasePassword=funcp"
+                ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name functional-${SUFFIX} ${XDEBUG_MODE} -e XDEBUG_CONFIG="${XDEBUG_CONFIG}" ${CONTAINERPARAMS} ${IMAGE_PHP} ${COMMAND}
+                SUITE_EXIT_CODE=$?
+                ;;
+            postgres)
+                ${CONTAINER_BIN} run --name postgres-func-${SUFFIX} --network ${NETWORK} -d -e POSTGRES_PASSWORD=funcp -e POSTGRES_USER=funcu --tmpfs /var/lib/postgresql/data:rw,noexec,nosuid ${IMAGE_POSTGRES} >/dev/null
+                waitFor postgres-func-${SUFFIX} 5432
+                CONTAINERPARAMS="-e typo3DatabaseDriver=pdo_pgsql -e typo3DatabaseName=bamboo -e typo3DatabaseUsername=funcu -e typo3DatabaseHost=postgres-func-${SUFFIX} -e typo3DatabasePassword=funcp"
+                ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name functional-${SUFFIX} ${XDEBUG_MODE} -e XDEBUG_CONFIG="${XDEBUG_CONFIG}" ${CONTAINERPARAMS} ${IMAGE_PHP} ${COMMAND}
+                SUITE_EXIT_CODE=$?
+                ;;
+            sqlite)
+                # create sqlite tmpfs mount typo3temp/var/tests/functional-sqlite-dbs/ to avoid permission issues
+                mkdir -p "${ROOT_DIR}/typo3temp/var/tests/functional-sqlite-dbs/"
+                CONTAINERPARAMS="-e typo3DatabaseDriver=pdo_sqlite --tmpfs ${ROOT_DIR}/typo3temp/var/tests/functional-sqlite-dbs/:rw,noexec,nosuid,uid=${HOST_UID}"
+                ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name functional-${SUFFIX} ${XDEBUG_MODE} -e XDEBUG_CONFIG="${XDEBUG_CONFIG}" ${CONTAINERPARAMS} ${IMAGE_PHP} ${COMMAND}
+                SUITE_EXIT_CODE=$?
+                ;;
+        esac
+        ;;
+    lintTypoScript)
+        COMMAND="composer ci:ts:lint"
+        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name composer-command-${SUFFIX} -e COMPOSER_CACHE_DIR=.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} /bin/sh -c "${COMMAND}"
+        SUITE_EXIT_CODE=$?
+        ;;
+    lintPhp)
+        COMMAND="composer ci:php:lint"
+        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name composer-command-${SUFFIX} -e COMPOSER_CACHE_DIR=.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} /bin/sh -c "${COMMAND}"
+        SUITE_EXIT_CODE=$?
+        ;;
+    lintJson)
+        COMMAND="composer ci:json:lint"
+        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name composer-command-${SUFFIX} -e COMPOSER_CACHE_DIR=.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} /bin/sh -c "${COMMAND}"
+        SUITE_EXIT_CODE=$?
+        ;;
+    lintYaml)
+        COMMAND="composer ci:yaml:lint"
+        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name composer-command-${SUFFIX} -e COMPOSER_CACHE_DIR=.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} /bin/sh -c "${COMMAND}"
+        SUITE_EXIT_CODE=$?
+        ;;
+    phpstan)
+        COMMAND="composer ci:php:stan"
+        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name composer-command-${SUFFIX} -e COMPOSER_CACHE_DIR=.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} /bin/sh -c "${COMMAND}"
+        SUITE_EXIT_CODE=$?
+        ;;
+    phpstanGenerateBaseline)
+        COMMAND="composer phpstan:baseline"
+        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name composer-command-${SUFFIX} -e COMPOSER_CACHE_DIR=.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} /bin/sh -c "${COMMAND}"
+        SUITE_EXIT_CODE=$?
+        ;;
+    unit)
+        [ -z "${TEST_FILE}" ] && TEST_FILE="Tests/Unit"
+        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name unit-${SUFFIX} ${XDEBUG_MODE} -e XDEBUG_CONFIG="${XDEBUG_CONFIG}" ${IMAGE_PHP} .Build/bin/phpunit -c .Build/vendor/typo3/testing-framework/Resources/Core/Build/UnitTests.xml ${EXTRA_TEST_OPTIONS} ${TEST_FILE}
+        SUITE_EXIT_CODE=$?
+        ;;
+    unitRandom)
+        [ -z "${TEST_FILE}" ] && TEST_FILE="Tests/Unit"
+        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name unit-random-${SUFFIX} ${XDEBUG_MODE} -e XDEBUG_CONFIG="${XDEBUG_CONFIG}" ${IMAGE_PHP} .Build/bin/phpunit -c .Build/vendor/typo3/testing-framework/Resources/Core/Build/UnitTests.xml --order-by=random ${EXTRA_TEST_OPTIONS} ${PHPUNIT_RANDOM} ${TEST_FILE}
+        SUITE_EXIT_CODE=$?
+        ;;
+    update)
+        # prune unused, dangling local volumes
+        echo "> prune unused, dangling local volumes"
+        ${CONTAINER_BIN} volume ls -q -f driver=local -f dangling=true | awk '$0 ~ /^[0-9a-f]{64}$/ { print }' | xargs -I {} ${CONTAINER_BIN} volume rm {}
+        echo ""
+        # pull typo3/core-testing-*:latest versions of those ones that exist locally
+        echo "> pull ${TYPO3_IMAGE_PREFIX}core-testing-*:latest versions of those ones that exist locally"
+        ${CONTAINER_BIN} images ${TYPO3_IMAGE_PREFIX}core-testing-*:latest --format "{{.Repository}}:latest" | xargs -I {} ${CONTAINER_BIN} pull {}
+        echo ""
+        # remove "dangling" typo3/core-testing-* images (those tagged as <none>)
+        echo "> remove \"dangling\" ${TYPO3_IMAGE_PREFIX}core-testing-* images (those tagged as <none>)"
+        ${CONTAINER_BIN} images ${TYPO3_IMAGE_PREFIX}core-testing-* --filter "dangling=true" --format "{{.ID}}" | xargs -I {} ${CONTAINER_BIN} rmi {}
+        echo ""
+        ;;
+    *)
+        loadHelp
+        echo "Invalid -s option argument ${TEST_SUITE}" >&2
+        echo >&2
+        echo "${HELP}" >&2
+        exit 1
+        ;;
+esac
+
+cleanUp
+
+# Print summary
+echo "" >&2
+echo "###########################################################################" >&2
+echo "Result of ${TEST_SUITE}" >&2
+if [[ ${IS_CORE_CI} -eq 1 ]]; then
+    echo "Environment: CI" >&2
+else
+    echo "Environment: local" >&2
+fi
+echo "PHP: ${PHP_VERSION}" >&2
+echo "TYPO3: ${CORE_VERSION}" >&2
+if [[ ${TEST_SUITE} =~ ^functional$ ]]; then
+    case "${DBMS}" in
+        mariadb)
+            echo "DBMS: ${DBMS}  version ${MARIADB_VERSION}  driver ${DATABASE_DRIVER}" >&2
+            ;;
+        mysql)
+            echo "DBMS: ${DBMS}  version ${MYSQL_VERSION}  driver ${DATABASE_DRIVER}" >&2
+            ;;
+        postgres)
+            echo "DBMS: ${DBMS}  version ${POSTGRES_VERSION}" >&2
+            ;;
+        sqlite)
+            echo "DBMS: ${DBMS}" >&2
+            ;;
+    esac
+fi
+if [[ ${SUITE_EXIT_CODE} -eq 0 ]]; then
+    echo "SUCCESS" >&2
+else
+    echo "FAILURE" >&2
+fi
+echo "###########################################################################" >&2
+echo "" >&2
+
+# Exit with code of test suite - This script return non-zero if the executed test failed.
+exit $SUITE_EXIT_CODE

--- a/composer.json
+++ b/composer.json
@@ -174,6 +174,7 @@
 			"rm -rf .ddev",
 			"rm -rf .github",
 			"rm -rf .gitlab",
+			"rm -rf Build",
 			"rm -rf Tests",
 			"rm -rf tools",
 			"rm .editorconfig",


### PR DESCRIPTION
TYPO3 Core and related repositories like the `typo3/testing-framework`
or `typo3/styleguide` uses a bash script arround docker to execute all
scripts over different operating systems in a controlled and ensured
manner. This helps to reproduce locally failing jobs from a CI like
GitHub actions or GitLab.

TYPO3 core dropped recently the requirement for `docker-compose`,
reducing it to `docker` and preparing for dual usage with docker
and podman in the future.

This change integrates the current state as extension wrapper,
aligning contained suits with existing tools. Additionally, a
TYPO3 core version switch is integrated.

The added script is excluded from git archive building and    
during releasing.

A list of possible options can be display with:

```shell
Build/Scripts/runTests.sh -h
```

Overview of integrated features:

* `-p` to select the PHP version (7.4 - 8.3)
* `-s` to select the suite to execute
* `-t` to select the TYPO3 core version, mainly
  needed for the `composer` suits executions
* `-e` to provide additionally flags for phpunit
  executions, e.g. for unit and functional tests
* `-x` to enable xdebug trigger - this helps with
  debugging during unit or functional test
* `-d` to select the database backend to use, needed
  for functional test execution to start the correct
  database
* `-a` to select the used php driver for the `-d`
  database backend, if multiple options are possible
* `-i` to specify the mariadb version
* `-j` to specify the mysql version
* `-k` to specify the postgres version

Available suits (`-s`):

- cgl: Checks the code style with the PHP Coding Standards Fixer
  (PHP-CS-Fixer).
- cglFix: Fixes the code style with PHP-CS-Fixer."
- clean: clean up build, cache and testing related files and
  folders
- cleanBuild: clean up build related files and folders
- cleanCache: clean up cache related files and folders
- cleanRenderedDocumentation: clean up rendered documentation
  files and folders (Documentation-GENERATED-temp)
- cleanTests: clean up test related files and folders
- composer: "composer" with all remaining arguments dispatched.
- composerInstallMax: "composer update", with no platform.php config.
- composerInstallMin: "composer update --prefer-lowest", with
  platform.php set to PHP version x.x.0.
- docsGenerate: Renders the extension ReST documentation.
- functional: PHP functional tests
- lintTypoScript: TypoScript linting
- lintPhp: PHP linting
- lintJson: JSON linting
- lintYaml: YAML linting
- phpstan: phpstan tests
- phpstanGenerateBaseline: regenerate phpstan baseline, handy after
  phpstan updates
- unit (default): PHP unit tests
- unitRandom: PHP unit tests in random order, add -o <number> to use
  specific seed

Notes:

* Not everything is available directly for now in the `runTests.sh`
  and therefore not enabled in CI.

* Coverage related execution needs extended work and are therefore
  left out for now.

* `composer.json` protection for core version changes not included
  yet like the one or other advanced option.

* Intermediate cleanings for changing php versions and core versions
  not included yet and will follow.

* typo3/testing-framework template files **must** be copied to the
  extension or project and **must not** be used from the  vendor
  folder.

Resolves: #899
Releases: main
