### PR TITLE
[REGRESSION] Use ghcr docs render image

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -154,7 +154,12 @@
 		"ci:yaml:lint": "find . ! -path '*.Build/*' ! -path '*node_modules/*' -regextype egrep -regex '.*.ya?ml$' | xargs -r php ./.Build/bin/yaml-lint",
 		"coverage:create-directories": "mkdir -p .Build/logs .Build/coverage",
 		"docs:generate": [
-			"docker run --rm t3docs/render-documentation show-shell-commands > tempfile.sh; echo 'dockrun_t3rd makehtml' >> tempfile.sh; bash tempfile.sh; rm tempfile.sh"
+			"@docs:generate:pullimage",
+			"docker run --rm ghcr.io/t3docs/render-documentation show-shell-commands > tempfile.sh; echo 'dockrun_t3rd makehtml' >> tempfile.sh; bash tempfile.sh; rm tempfile.sh"
+		],
+		"docs:generate:pullimage": [
+			"docker pull ghcr.io/t3docs/render-documentation",
+			"docker tag ghcr.io/t3docs/render-documentation t3docs/render-documentation"
 		],
 		"fix:composer:normalize": "@composer normalize --no-check-lock",
 		"fix:php": [


### PR DESCRIPTION
The new runTests.sh relies on the ghcr.io image. However the image itself relies on a non-prefixed version of the image. Thus, the image can't be pulled automatically, because it needs to be tagged afterwards.

fixes #903