### PR TITLE
[TASK] Remove deprecated license scanning

### DIFF
--- a/.gitlab/pipeline/.gitlab-ci.yml
+++ b/.gitlab/pipeline/.gitlab-ci.yml
@@ -47,6 +47,5 @@ include:
   - '/.gitlab/pipeline/jobs/unit-php8.2-v12-lowest.yml'
   - '/.gitlab/pipeline/jobs/xliff-lint.yml'
   - '/.gitlab/pipeline/jobs/yaml-lint.yml'
-  - template: Security/License-Scanning.gitlab-ci.yml
   - template: Security/Secret-Detection.gitlab-ci.yml
   - template: Security/SAST.gitlab-ci.yml


### PR DESCRIPTION
The legacy License Compliance analyzer was deprecated in GitLab 15.9 and removed in GitLab 16.3. Bugs and vulnerabilities in this legacy analyzer will no longer be fixed. This error message can be resolved by removing Jobs/License-Scanning.gitlab-ci.yml from your CI configuration.
https://git.typo3.org/qa/example-extension/-/jobs/2694908