### PR TITLE
[TASK] Split up the DB fixtures for the functional tests

### DIFF
--- a/Tests/Functional/Domain/Repository/Fixtures/Product/Tea.csv
+++ b/Tests/Functional/Domain/Repository/Fixtures/Product/Tea.csv
@@ -1,8 +1,0 @@
-"tx_tea_domain_model_product_tea"
-,"uid","pid","title","description","image","owner"
-,"1","1","Earl Grey","Fresh and hot.",0,2
-,"2","1","Assam","Dark and strong.",0,0
-,"3","1","Gunpowder","Bitter and very green.",1,0
-"sys_file_reference"
-,"uid","pid","uid_foreign","tablenames","fieldname"
-,"1","1","3","tx_tea_domain_model_product_tea","image"

--- a/Tests/Functional/Domain/Repository/Fixtures/Product/TeaOnPage.csv
+++ b/Tests/Functional/Domain/Repository/Fixtures/Product/TeaOnPage.csv
@@ -1,0 +1,3 @@
+"tx_tea_domain_model_product_tea"
+,"uid","pid","title"
+,1,1,"Earl Grey"

--- a/Tests/Functional/Domain/Repository/Fixtures/Product/TeaWithAllScalarData.csv
+++ b/Tests/Functional/Domain/Repository/Fixtures/Product/TeaWithAllScalarData.csv
@@ -1,0 +1,3 @@
+"tx_tea_domain_model_product_tea"
+,"uid","pid","title","description","owner"
+,1,1,"Earl Grey","Fresh and hot.",2

--- a/Tests/Functional/Domain/Repository/Fixtures/Product/TeaWithImage.csv
+++ b/Tests/Functional/Domain/Repository/Fixtures/Product/TeaWithImage.csv
@@ -1,0 +1,7 @@
+"tx_tea_domain_model_product_tea"
+,"uid","pid","title","image",
+,1,1,"Gunpowder",1
+
+"sys_file_reference"
+,"uid","uid_foreign","tablenames","fieldname"
+,1,1,"tx_tea_domain_model_product_tea","image"

--- a/Tests/Functional/Domain/Repository/Fixtures/Product/TeaWithoutOwner.csv
+++ b/Tests/Functional/Domain/Repository/Fixtures/Product/TeaWithoutOwner.csv
@@ -1,3 +1,3 @@
 "tx_tea_domain_model_product_tea"
 ,"uid","pid","title","owner"
-,"1","1","Earl Grey",0
+,1,1,"Earl Grey",0

--- a/Tests/Functional/Domain/Repository/Fixtures/Product/TwoTeasWithOwner.csv
+++ b/Tests/Functional/Domain/Repository/Fixtures/Product/TwoTeasWithOwner.csv
@@ -1,4 +1,4 @@
 "tx_tea_domain_model_product_tea"
 ,"uid","pid","title","owner"
-,"1","1","Earl Grey",1
-,"2","1","Assam",1
+,1,1,"Earl Grey",1
+,2,1,"Assam",1

--- a/Tests/Functional/Domain/Repository/Fixtures/Product/TwoUnsortedTeas.csv
+++ b/Tests/Functional/Domain/Repository/Fixtures/Product/TwoUnsortedTeas.csv
@@ -1,0 +1,4 @@
+"tx_tea_domain_model_product_tea"
+,"uid","pid","title"
+,1,1,"Earl Grey"
+,2,1,"Assam"

--- a/Tests/Functional/Domain/Repository/Product/TeaRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/Product/TeaRepositoryTest.php
@@ -46,11 +46,11 @@ final class TeaRepositoryTest extends FunctionalTestCase
      */
     public function findAllWithRecordsFindsRecordsFromAllPages(): void
     {
-        $this->importCSVDataSet(__DIR__ . '/../Fixtures/Product/Tea.csv');
+        $this->importCSVDataSet(__DIR__ . '/../Fixtures/Product/TeaOnPage.csv');
 
         $result = $this->subject->findAll();
 
-        self::assertGreaterThanOrEqual(1, \count($result));
+        self::assertCount(1, $result);
     }
 
     /**
@@ -58,7 +58,7 @@ final class TeaRepositoryTest extends FunctionalTestCase
      */
     public function findAllSortsByTitleInAscendingOrder(): void
     {
-        $this->importCSVDataSet(__DIR__ . '/../Fixtures/Product/Tea.csv');
+        $this->importCSVDataSet(__DIR__ . '/../Fixtures/Product/TwoUnsortedTeas.csv');
 
         $result = $this->subject->findAll();
 
@@ -71,7 +71,7 @@ final class TeaRepositoryTest extends FunctionalTestCase
      */
     public function findByUidForExistingRecordReturnsModel(): void
     {
-        $this->importCSVDataSet(__DIR__ . '/../Fixtures/Product/Tea.csv');
+        $this->importCSVDataSet(__DIR__ . '/../Fixtures/Product/TeaWithAllScalarData.csv');
 
         $model = $this->subject->findByUid(1);
 
@@ -83,7 +83,7 @@ final class TeaRepositoryTest extends FunctionalTestCase
      */
     public function findByUidForExistingRecordMapsAllScalarData(): void
     {
-        $this->importCSVDataSet(__DIR__ . '/../Fixtures/Product/Tea.csv');
+        $this->importCSVDataSet(__DIR__ . '/../Fixtures/Product/TeaWithAllScalarData.csv');
 
         $model = $this->subject->findByUid(1);
         self::assertInstanceOf(Tea::class, $model);
@@ -98,9 +98,9 @@ final class TeaRepositoryTest extends FunctionalTestCase
      */
     public function fillsImageRelation(): void
     {
-        $this->importCSVDataSet(__DIR__ . '/../Fixtures/Product/Tea.csv');
+        $this->importCSVDataSet(__DIR__ . '/../Fixtures/Product/TeaWithImage.csv');
 
-        $model = $this->subject->findByUid(3);
+        $model = $this->subject->findByUid(1);
 
         $image = $model->getImage();
         self::assertInstanceOf(FileReference::class, $image);


### PR DESCRIPTION
This makes the fixture more minimal and reduces cross-dependencies between tests.

Also consistently avoid quotes for integer data in CSV DB fixtures.

Fixes #988