### PR TITLE
[CLEANUP] Use more stubs instead of mocks

### DIFF
--- a/Tests/Unit/Controller/FrontEndEditorControllerTest.php
+++ b/Tests/Unit/Controller/FrontEndEditorControllerTest.php
@@ -114,7 +114,7 @@ final class FrontEndEditorControllerTest extends UnitTestCase
         $userUid = 5;
         $this->setUidOfLoggedInUser($userUid);
 
-        $teas = $this->createMock(QueryResultInterface::class);
+        $teas = $this->createStub(QueryResultInterface::class);
         $this->teaRepositoryMock->method('findByOwnerUid')->with($userUid)->willReturn($teas);
         $this->viewMock->expects(self::once())->method('assign')->with('teas', $teas);
 

--- a/Tests/Unit/Controller/TeaControllerTest.php
+++ b/Tests/Unit/Controller/TeaControllerTest.php
@@ -68,7 +68,7 @@ final class TeaControllerTest extends UnitTestCase
      */
     public function indexActionAssignsAllTeaAsTeasToView(): void
     {
-        $teas = $this->createMock(QueryResultInterface::class);
+        $teas = $this->createStub(QueryResultInterface::class);
         $this->teaRepositoryMock->method('findAll')->willReturn($teas);
         $this->viewMock->expects(self::once())->method('assign')->with('teas', $teas);
 


### PR DESCRIPTION
This makes the purpose of the test doubles more clear to the reader.

Fixes #986