### PR TITLE
[TASK] Remove obsolete symlink for functional tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -109,9 +109,6 @@
 		}
 	},
 	"scripts": {
-		"post-autoload-dump": [
-			"@link-extension"
-		],
 		"ci": [
 			"@ci:static"
 		],
@@ -181,10 +178,6 @@
 		],
 		"fix:php:cs": "php-cs-fixer fix --config .php-cs-fixer.php",
 		"fix:php:sniff": "phpcbf Classes Configuration Tests",
-		"link-extension": [
-			"@php -r 'is_dir($extFolder=__DIR__.\"/.Build/Web/typo3conf/ext/\") || mkdir($extFolder, 0777, true);'",
-			"@php -r 'file_exists($extFolder=__DIR__.\"/.Build/Web/typo3conf/ext/tea\") || symlink(__DIR__,$extFolder);'"
-		],
 		"phpstan:baseline": ".Build/bin/phpstan  --generate-baseline=phpstan-baseline.neon",
 		"prepare-release": [
 			"rm .gitignore",


### PR DESCRIPTION
The symlinking is no longer necessary, thanks to
https://github.com/TYPO3/testing-framework/pull/434

Resolves: #1000