### PR TITLE
[CLEANUP] Migrate typo3conf path to composer package name

### DIFF
--- a/Tests/Functional/Domain/Repository/Product/TeaRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/Product/TeaRepositoryTest.php
@@ -16,7 +16,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class TeaRepositoryTest extends FunctionalTestCase
 {
-    protected array $testExtensionsToLoad = ['typo3conf/ext/tea'];
+    protected array $testExtensionsToLoad = ['ttn/tea'];
 
     private TeaRepository $subject;
 


### PR DESCRIPTION
The tests now respect the TYPO3 extension key as well as the composer package name.
There is no more need to use the old (no longer used) typo3conf/ext path.

Resolves: #739