### PR TITLE
[TASK] Output the job name in the GitLab CI builds

### DIFF
--- a/.gitlab/pipeline/jobs/func-php7.4-v11-highest.yml
+++ b/.gitlab/pipeline/jobs/func-php7.4-v11-highest.yml
@@ -8,6 +8,7 @@ func-php7.4-v11-highest:
     - build-composer-dependencies
     - php-lint-php7.4
   script:
+    - echo "Job ${CI_JOB_NAME}"
     - composer require --no-ansi --no-interaction --no-progress --no-install typo3/cms-core:"^11.5"
     - composer update --no-ansi --no-interaction --no-progress --with-dependencies
     - wait-for-it mariadb:3306 -t 60 --strict -- composer ci:tests:functional

--- a/.gitlab/pipeline/jobs/func-php7.4-v11-lowest.yml
+++ b/.gitlab/pipeline/jobs/func-php7.4-v11-lowest.yml
@@ -8,6 +8,7 @@ func-php7.4-v11-lowest:
     - build-composer-dependencies
     - php-lint-php7.4
   script:
+    - echo "Job ${CI_JOB_NAME}"
     - composer require --no-ansi --no-interaction --no-progress --no-install typo3/cms-core:"^11.5"
     - composer update --no-ansi --no-interaction --no-progress --with-dependencies --prefer-lowest
     - wait-for-it mariadb:3306 -t 60 --strict -- composer ci:tests:functional

--- a/.gitlab/pipeline/jobs/func-php8.0-v11-highest.yml
+++ b/.gitlab/pipeline/jobs/func-php8.0-v11-highest.yml
@@ -8,6 +8,7 @@ func-php8.0-v11-highest:
     - build-composer-dependencies
     - php-lint-php8.0
   script:
+    - echo "Job ${CI_JOB_NAME}"
     - composer require --no-ansi --no-interaction --no-progress --no-install typo3/cms-core:"^11.5"
     - composer update --no-ansi --no-interaction --no-progress --with-dependencies
     - wait-for-it mariadb:3306 -t 60 --strict -- composer ci:tests:functional

--- a/.gitlab/pipeline/jobs/func-php8.0-v11-lowest.yml
+++ b/.gitlab/pipeline/jobs/func-php8.0-v11-lowest.yml
@@ -8,6 +8,7 @@ func-php8.0-v11-lowest:
     - build-composer-dependencies
     - php-lint-php8.0
   script:
+    - echo "Job ${CI_JOB_NAME}"
     - composer require --no-ansi --no-interaction --no-progress --no-install typo3/cms-core:"^11.5"
     - composer update --no-ansi --no-interaction --no-progress --with-dependencies --prefer-lowest
     - wait-for-it mariadb:3306 -t 60 --strict -- composer ci:tests:functional

--- a/.gitlab/pipeline/jobs/func-php8.1-v11-highest.yml
+++ b/.gitlab/pipeline/jobs/func-php8.1-v11-highest.yml
@@ -8,6 +8,7 @@ func-php8.1-v11-highest:
     - build-composer-dependencies
     - php-lint-php8.1
   script:
+    - echo "Job ${CI_JOB_NAME}"
     - composer require --no-ansi --no-interaction --no-progress --no-install typo3/cms-core:"^11.5"
     - composer update --no-ansi --no-interaction --no-progress --with-dependencies
     - wait-for-it mariadb:3306 -t 60 --strict -- composer ci:tests:functional

--- a/.gitlab/pipeline/jobs/func-php8.1-v11-lowest.yml
+++ b/.gitlab/pipeline/jobs/func-php8.1-v11-lowest.yml
@@ -8,6 +8,7 @@ func-php8.1-v11-lowest:
     - build-composer-dependencies
     - php-lint-php8.1
   script:
+    - echo "Job ${CI_JOB_NAME}"
     - composer require --no-ansi --no-interaction --no-progress --no-install typo3/cms-core:"^11.5"
     - composer update --no-ansi --no-interaction --no-progress --with-dependencies --prefer-lowest
     - wait-for-it mariadb:3306 -t 60 --strict -- composer ci:tests:functional

--- a/.gitlab/pipeline/jobs/func-php8.1-v12-highest.yml
+++ b/.gitlab/pipeline/jobs/func-php8.1-v12-highest.yml
@@ -8,6 +8,7 @@ func-php8.1-v11-highest:
     - build-composer-dependencies
     - php-lint-php8.1
   script:
+    - echo "Job ${CI_JOB_NAME}"
     - composer require --no-ansi --no-interaction --no-progress --no-install typo3/cms-core:"^12.4"
     - composer update --no-ansi --no-interaction --no-progress --with-dependencies
     - wait-for-it mariadb:3306 -t 60 --strict -- composer ci:tests:functional

--- a/.gitlab/pipeline/jobs/func-php8.1-v12-lowest.yml
+++ b/.gitlab/pipeline/jobs/func-php8.1-v12-lowest.yml
@@ -8,6 +8,7 @@ func-php8.1-v11-lowest:
     - build-composer-dependencies
     - php-lint-php8.1
   script:
+    - echo "Job ${CI_JOB_NAME}"
     - composer require --no-ansi --no-interaction --no-progress --no-install typo3/cms-core:"^12.4"
     - composer update --no-ansi --no-interaction --no-progress --with-dependencies --prefer-lowest
     - wait-for-it mariadb:3306 -t 60 --strict -- composer ci:tests:functional

--- a/.gitlab/pipeline/jobs/func-php8.2-v11-highest.yml
+++ b/.gitlab/pipeline/jobs/func-php8.2-v11-highest.yml
@@ -8,6 +8,7 @@ func-php8.2-v11-highest:
     - build-composer-dependencies
     - php-lint-php8.2
   script:
+    - echo "Job ${CI_JOB_NAME}"
     - composer require --no-ansi --no-interaction --no-progress --no-install typo3/cms-core:"^11.5"
     - composer update --no-ansi --no-interaction --no-progress --with-dependencies
     - wait-for-it mariadb:3306 -t 60 --strict -- composer ci:tests:functional

--- a/.gitlab/pipeline/jobs/func-php8.2-v11-lowest.yml
+++ b/.gitlab/pipeline/jobs/func-php8.2-v11-lowest.yml
@@ -8,6 +8,7 @@ func-php8.2-v11-lowest:
     - build-composer-dependencies
     - php-lint-php8.2
   script:
+    - echo "Job ${CI_JOB_NAME}"
     - composer require --no-ansi --no-interaction --no-progress --no-install typo3/cms-core:"^11.5"
     - composer update --no-ansi --no-interaction --no-progress --with-dependencies --prefer-lowest
     - wait-for-it mariadb:3306 -t 60 --strict -- composer ci:tests:functional

--- a/.gitlab/pipeline/jobs/func-php8.2-v12-highest.yml
+++ b/.gitlab/pipeline/jobs/func-php8.2-v12-highest.yml
@@ -8,6 +8,7 @@ func-php8.2-v11-highest:
     - build-composer-dependencies
     - php-lint-php8.2
   script:
+    - echo "Job ${CI_JOB_NAME}"
     - composer require --no-ansi --no-interaction --no-progress --no-install typo3/cms-core:"^12.4"
     - composer update --no-ansi --no-interaction --no-progress --with-dependencies
     - wait-for-it mariadb:3306 -t 60 --strict -- composer ci:tests:functional

--- a/.gitlab/pipeline/jobs/func-php8.2-v12-lowest.yml
+++ b/.gitlab/pipeline/jobs/func-php8.2-v12-lowest.yml
@@ -8,6 +8,7 @@ func-php8.2-v11-lowest:
     - build-composer-dependencies
     - php-lint-php8.2
   script:
+    - echo "Job ${CI_JOB_NAME}"
     - composer require --no-ansi --no-interaction --no-progress --no-install typo3/cms-core:"^12.4"
     - composer update --no-ansi --no-interaction --no-progress --with-dependencies --prefer-lowest
     - wait-for-it mariadb:3306 -t 60 --strict -- composer ci:tests:functional

--- a/.gitlab/pipeline/jobs/unit-php7.4-v11-highest.yml
+++ b/.gitlab/pipeline/jobs/unit-php7.4-v11-highest.yml
@@ -6,6 +6,7 @@ unit-php7.4-v11-highest:
     - build-composer-dependencies
     - php-lint-php7.4
   script:
+    - echo "Job ${CI_JOB_NAME}"
     - composer require --no-ansi --no-interaction --no-progress --no-install typo3/cms-core:"^11.5"
     - composer update --no-ansi --no-interaction --no-progress --with-dependencies
     - composer ci:tests:unit

--- a/.gitlab/pipeline/jobs/unit-php7.4-v11-lowest.yml
+++ b/.gitlab/pipeline/jobs/unit-php7.4-v11-lowest.yml
@@ -6,6 +6,7 @@ unit-php7.4-v11-lowest:
     - build-composer-dependencies
     - php-lint-php7.4
   script:
+    - echo "Job ${CI_JOB_NAME}"
     - composer require --no-ansi --no-interaction --no-progress --no-install typo3/cms-core:"^11.5"
     - composer update --no-ansi --no-interaction --no-progress --with-dependencies --prefer-lowest
     - composer ci:tests:unit

--- a/.gitlab/pipeline/jobs/unit-php8.0-v11-highest.yml
+++ b/.gitlab/pipeline/jobs/unit-php8.0-v11-highest.yml
@@ -6,6 +6,7 @@ unit-php8.0-v11-highest:
     - build-composer-dependencies
     - php-lint-php8.0
   script:
+    - echo "Job ${CI_JOB_NAME}"
     - composer require --no-ansi --no-interaction --no-progress --no-install typo3/cms-core:"^11.5"
     - composer update --no-ansi --no-interaction --no-progress --with-dependencies
     - composer ci:tests:unit

--- a/.gitlab/pipeline/jobs/unit-php8.0-v11-lowest.yml
+++ b/.gitlab/pipeline/jobs/unit-php8.0-v11-lowest.yml
@@ -6,6 +6,7 @@ unit-php8.0-v11-lowest:
     - build-composer-dependencies
     - php-lint-php8.0
   script:
+    - echo "Job ${CI_JOB_NAME}"
     - composer require --no-ansi --no-interaction --no-progress --no-install typo3/cms-core:"^11.5"
     - composer update --no-ansi --no-interaction --no-progress --with-dependencies --prefer-lowest
     - composer ci:tests:unit

--- a/.gitlab/pipeline/jobs/unit-php8.1-v11-highest.yml
+++ b/.gitlab/pipeline/jobs/unit-php8.1-v11-highest.yml
@@ -6,6 +6,7 @@ unit-php8.1-v11-highest:
     - build-composer-dependencies
     - php-lint-php8.1
   script:
+    - echo "Job ${CI_JOB_NAME}"
     - composer require --no-ansi --no-interaction --no-progress --no-install typo3/cms-core:"^11.5"
     - composer update --no-ansi --no-interaction --no-progress --with-dependencies
     - composer ci:tests:unit

--- a/.gitlab/pipeline/jobs/unit-php8.1-v11-lowest.yml
+++ b/.gitlab/pipeline/jobs/unit-php8.1-v11-lowest.yml
@@ -6,6 +6,7 @@ unit-php8.1-v11-lowest:
     - build-composer-dependencies
     - php-lint-php8.1
   script:
+    - echo "Job ${CI_JOB_NAME}"
     - composer require --no-ansi --no-interaction --no-progress --no-install typo3/cms-core:"^11.5"
     - composer update --no-ansi --no-interaction --no-progress --with-dependencies --prefer-lowest
     - composer ci:tests:unit

--- a/.gitlab/pipeline/jobs/unit-php8.1-v12-highest.yml
+++ b/.gitlab/pipeline/jobs/unit-php8.1-v12-highest.yml
@@ -6,5 +6,6 @@ unit-php8.1-v12-highest:
     - build-composer-dependencies
     - php-lint-php8.1
   script:
+    - echo "Job ${CI_JOB_NAME}"
     - composer require --no-progress typo3/cms-core:"^12.4"
     - composer ci:tests:unit

--- a/.gitlab/pipeline/jobs/unit-php8.1-v12-lowest.yml
+++ b/.gitlab/pipeline/jobs/unit-php8.1-v12-lowest.yml
@@ -6,6 +6,7 @@ unit-php8.1-v12-lowest:
     - build-composer-dependencies
     - php-lint-php8.1
   script:
+    - echo "Job ${CI_JOB_NAME}"
     - composer require --no-ansi --no-interaction --no-progress --no-install typo3/cms-core:"^12.4"
     - composer update --no-ansi --no-interaction --no-progress --with-dependencies --prefer-lowest
     - composer ci:tests:unit

--- a/.gitlab/pipeline/jobs/unit-php8.2-v11-highest.yml
+++ b/.gitlab/pipeline/jobs/unit-php8.2-v11-highest.yml
@@ -6,6 +6,7 @@ unit-php8.2-v11-highest:
     - build-composer-dependencies
     - php-lint-php8.2
   script:
+    - echo "Job ${CI_JOB_NAME}"
     - composer require --no-ansi --no-interaction --no-progress --no-install typo3/cms-core:"^11.5"
     - composer update --no-ansi --no-interaction --no-progress --with-dependencies
     - composer ci:tests:unit

--- a/.gitlab/pipeline/jobs/unit-php8.2-v11-lowest.yml
+++ b/.gitlab/pipeline/jobs/unit-php8.2-v11-lowest.yml
@@ -6,6 +6,7 @@ unit-php8.2-v11-lowest:
     - build-composer-dependencies
     - php-lint-php8.2
   script:
+    - echo "Job ${CI_JOB_NAME}"
     - composer require --no-ansi --no-interaction --no-progress --no-install typo3/cms-core:"^11.5"
     - composer update --no-ansi --no-interaction --no-progress --with-dependencies --prefer-lowest
     - composer ci:tests:unit

--- a/.gitlab/pipeline/jobs/unit-php8.2-v12-highest.yml
+++ b/.gitlab/pipeline/jobs/unit-php8.2-v12-highest.yml
@@ -6,5 +6,6 @@ unit-php8.2-v12-highest:
     - build-composer-dependencies
     - php-lint-php8.2
   script:
+    - echo "Job ${CI_JOB_NAME}"
     - composer require --no-progress typo3/cms-core:"^12.4"
     - composer ci:tests:unit

--- a/.gitlab/pipeline/jobs/unit-php8.2-v12-lowest.yml
+++ b/.gitlab/pipeline/jobs/unit-php8.2-v12-lowest.yml
@@ -6,6 +6,7 @@ unit-php8.2-v12-lowest:
     - build-composer-dependencies
     - php-lint-php8.2
   script:
+    - echo "Job ${CI_JOB_NAME}"
     - composer require --no-ansi --no-interaction --no-progress --no-install typo3/cms-core:"^12.4"
     - composer update --no-ansi --no-interaction --no-progress --with-dependencies --prefer-lowest
     - composer ci:tests:unit


### PR DESCRIPTION
Some GitLab jobs seem to run commands that do not belong in the the corresponding job.

This change outputs the job name in CI in order to help us track this down.

Related: #976