### PR TITLE
[BUGFIX] Wrong GitLab job name

### DIFF
--- a/.gitlab/pipeline/jobs/func-php8.2-v12-lowest.yml
+++ b/.gitlab/pipeline/jobs/func-php8.2-v12-lowest.yml
@@ -1,4 +1,4 @@
-func-php8.2-v11-lowest:
+func-php8.2-v12-lowest:
   extends: .default
   image: php:8.2
   services:


### PR DESCRIPTION
The job name did not match the file name and the actual content of the job.

Relates: #976