### PR TITLE
[!!!][TASK] Drop additional namespace segment for the Tea model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 ### Changed
+- Drop additional namespace segment for the Tea model (#1025)
 
 ### Deprecated
 

--- a/Classes/Controller/FrontEndEditorController.php
+++ b/Classes/Controller/FrontEndEditorController.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace TTN\Tea\Controller;
 
 use Psr\Http\Message\ResponseInterface;
-use TTN\Tea\Domain\Model\Product\Tea;
-use TTN\Tea\Domain\Repository\Product\TeaRepository;
+use TTN\Tea\Domain\Model\Tea;
+use TTN\Tea\Domain\Repository\TeaRepository;
 use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Annotation as Extbase;

--- a/Classes/Controller/TeaController.php
+++ b/Classes/Controller/TeaController.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace TTN\Tea\Controller;
 
 use Psr\Http\Message\ResponseInterface;
-use TTN\Tea\Domain\Model\Product\Tea;
-use TTN\Tea\Domain\Repository\Product\TeaRepository;
+use TTN\Tea\Domain\Model\Tea;
+use TTN\Tea\Domain\Repository\TeaRepository;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 
 /**

--- a/Classes/Domain/Model/Tea.php
+++ b/Classes/Domain/Model/Tea.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace TTN\Tea\Domain\Model\Product;
+namespace TTN\Tea\Domain\Model;
 
 use TYPO3\CMS\Extbase\Annotation as Extbase;
 use TYPO3\CMS\Extbase\Domain\Model\FileReference;

--- a/Classes/Domain/Repository/TeaRepository.php
+++ b/Classes/Domain/Repository/TeaRepository.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace TTN\Tea\Domain\Repository\Product;
+namespace TTN\Tea\Domain\Repository;
 
-use TTN\Tea\Domain\Model\Product\Tea;
+use TTN\Tea\Domain\Model\Tea;
 use TTN\Tea\Domain\Repository\Traits\StoragePageAgnosticTrait;
 use TYPO3\CMS\Extbase\Persistence\QueryInterface;
 use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;

--- a/Configuration/Extbase/Persistence/Classes.php
+++ b/Configuration/Extbase/Persistence/Classes.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 return [
-    \TTN\Tea\Domain\Model\Product\Tea::class => [
+    \TTN\Tea\Domain\Model\Tea::class => [
         'properties' => [
             'ownerUid' => ['fieldName' => 'owner'],
         ],

--- a/Configuration/TCA/tx_tea_domain_model_tea.php
+++ b/Configuration/TCA/tx_tea_domain_model_tea.php
@@ -2,7 +2,7 @@
 
 $tca = [
     'ctrl' => [
-        'title' => 'LLL:EXT:tea/Resources/Private/Language/locallang_db.xlf:tx_tea_domain_model_product_tea',
+        'title' => 'LLL:EXT:tea/Resources/Private/Language/locallang_db.xlf:tx_tea_domain_model_tea',
         'label' => 'title',
         'tstamp' => 'tstamp',
         'crdate' => 'crdate',
@@ -26,7 +26,7 @@ $tca = [
             'showitem' =>
                 '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general,
                     title, description, image, owner,
-                 --div--;LLL:EXT:tea/Resources/Private/Language/locallang_db.xlf:tx_tea_domain_model_product_tea.tabs.access,
+                 --div--;LLL:EXT:tea/Resources/Private/Language/locallang_db.xlf:tx_tea_domain_model_tea.tabs.access,
                     --palette--;;hidden,
                     --palette--;;access,',
         ],
@@ -34,11 +34,11 @@ $tca = [
     'palettes' => [
         'hidden' => [
             'showitem' => '
-                hidden;LLL:EXT:tea/Resources/Private/Language/locallang_db.xlf:tx_tea_domain_model_product_tea.hidden
+                hidden;LLL:EXT:tea/Resources/Private/Language/locallang_db.xlf:tx_tea_domain_model_tea.hidden
             ',
         ],
         'access' => [
-            'label' => 'LLL:EXT:tea/Resources/Private/Language/locallang_db.xlf:tx_tea_domain_model_product_tea.palettes.access',
+            'label' => 'LLL:EXT:tea/Resources/Private/Language/locallang_db.xlf:tx_tea_domain_model_tea.palettes.access',
             'showitem' => '
                 starttime;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:starttime_formlabel,
                 endtime;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:endtime_formlabel,
@@ -50,7 +50,7 @@ $tca = [
     'columns' => [
         'hidden' => [
             'exclude' => true,
-            'label' => 'LLL:EXT:tea/Resources/Private/Language/locallang_db.xlf:tx_tea_domain_model_product_tea.hidden',
+            'label' => 'LLL:EXT:tea/Resources/Private/Language/locallang_db.xlf:tx_tea_domain_model_tea.hidden',
             'config' => [
                 'type' => 'check',
                 'renderType' => 'checkboxToggle',
@@ -107,10 +107,10 @@ $tca = [
                         'value' => 0,
                     ],
                 ],
-                'foreign_table' => 'tx_tea_domain_model_product_tea',
+                'foreign_table' => 'tx_tea_domain_model_tea',
                 'foreign_table_where' =>
-                    'AND {#tx_tea_domain_model_product_tea}.{#pid}=###CURRENT_PID###
-                     AND {#tx_tea_domain_model_product_tea}.{#sys_language_uid} IN (-1,0)',
+                    'AND {#tx_tea_domain_model_tea}.{#pid}=###CURRENT_PID###
+                     AND {#tx_tea_domain_model_tea}.{#sys_language_uid} IN (-1,0)',
                 'default' => 0,
             ],
         ],
@@ -126,7 +126,7 @@ $tca = [
             ],
         ],
         'title' => [
-            'label' => 'LLL:EXT:tea/Resources/Private/Language/locallang_db.xlf:tx_tea_domain_model_product_tea.title',
+            'label' => 'LLL:EXT:tea/Resources/Private/Language/locallang_db.xlf:tx_tea_domain_model_tea.title',
             'config' => [
                 'type' => 'input',
                 'size' => 40,
@@ -136,7 +136,7 @@ $tca = [
             ],
         ],
         'description' => [
-            'label' => 'LLL:EXT:tea/Resources/Private/Language/locallang_db.xlf:tx_tea_domain_model_product_tea.description',
+            'label' => 'LLL:EXT:tea/Resources/Private/Language/locallang_db.xlf:tx_tea_domain_model_tea.description',
             'config' => [
                 'type' => 'text',
                 'enableRichtext' => true,
@@ -147,7 +147,7 @@ $tca = [
             ],
         ],
         'image' => [
-            'label' => 'LLL:EXT:tea/Resources/Private/Language/locallang_db.xlf:tx_tea_domain_model_product_tea.image',
+            'label' => 'LLL:EXT:tea/Resources/Private/Language/locallang_db.xlf:tx_tea_domain_model_tea.image',
             'config' => [
                 'type' => 'file',
                 'maxitems' => 1,
@@ -164,7 +164,7 @@ $tca = [
         'fe_group' => [
             'exclude' => true,
             'l10n_mode' => 'exclude',
-            'label' => 'LLL:EXT:tea/Resources/Private/Language/locallang_db.xlf:tx_tea_domain_model_product_tea.fe_group',
+            'label' => 'LLL:EXT:tea/Resources/Private/Language/locallang_db.xlf:tx_tea_domain_model_tea.fe_group',
             'config' => [
                 'type' => 'select',
                 'renderType' => 'selectMultipleSideBySide',
@@ -191,7 +191,7 @@ $tca = [
         'owner' => [
             'exclude' => true,
             'l10n_mode' => 'exclude',
-            'label' => 'LLL:EXT:tea/Resources/Private/Language/locallang_db.xlf:tx_tea_domain_model_product_tea.owner',
+            'label' => 'LLL:EXT:tea/Resources/Private/Language/locallang_db.xlf:tx_tea_domain_model_tea.owner',
             'config' => [
                 'type' => 'group',
                 'allowed' => 'fe_users',
@@ -231,7 +231,7 @@ if ($typo3Version->getMajorVersion() < 12) {
         ],
     ];
     $tca['columns']['image'] = [
-        'label' => 'LLL:EXT:tea/Resources/Private/Language/locallang_db.xlf:tx_tea_domain_model_product_tea.image',
+        'label' => 'LLL:EXT:tea/Resources/Private/Language/locallang_db.xlf:tx_tea_domain_model_tea.image',
         'config' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getFileFieldTCAConfig(
             'image',
             [
@@ -248,7 +248,7 @@ if ($typo3Version->getMajorVersion() < 12) {
     ];
     $tca['columns']['hidden']['config'] = [
         'type' => 'check',
-        'label' => 'LLL:EXT:tea/Resources/Private/Language/locallang_db.xlf:tx_tea_domain_model_product_tea.hidden',
+        'label' => 'LLL:EXT:tea/Resources/Private/Language/locallang_db.xlf:tx_tea_domain_model_tea.hidden',
         'items' => [
             [
                 0 => '',

--- a/Resources/Private/Language/de.locallang_db.xlf
+++ b/Resources/Private/Language/de.locallang_db.xlf
@@ -3,35 +3,35 @@
 	<file source-language="en" target-language="de" datatype="plaintext" original="messages">
 		<header/>
 		<body>
-			<trans-unit id="tx_tea_domain_model_product_tea">
+			<trans-unit id="tx_tea_domain_model_tea">
 				<source>Tea</source>
 				<target>Tee</target>
 			</trans-unit>
-			<trans-unit id="tx_tea_domain_model_product_tea.tabs.access">
+			<trans-unit id="tx_tea_domain_model_tea.tabs.access">
 				<source>Access</source>
 				<target>Zugriff</target>
 			</trans-unit>
-			<trans-unit id="tx_tea_domain_model_product_tea.title">
+			<trans-unit id="tx_tea_domain_model_tea.title">
 				<source>Title</source>
 				<target>Titel</target>
 			</trans-unit>
-			<trans-unit id="tx_tea_domain_model_product_tea.description">
+			<trans-unit id="tx_tea_domain_model_tea.description">
 				<source>Description</source>
 				<target>Beschreibung</target>
 			</trans-unit>
-			<trans-unit id="tx_tea_domain_model_product_tea.image">
+			<trans-unit id="tx_tea_domain_model_tea.image">
 				<source>Image</source>
 				<target>Bild</target>
 			</trans-unit>
-			<trans-unit id="tx_tea_domain_model_product_tea.owner">
+			<trans-unit id="tx_tea_domain_model_tea.owner">
 				<source>Website user who created this record</source>
 				<target>Website-Benutzer, der diesen Datensatz erstellt hat</target>
 			</trans-unit>
-			<trans-unit id="tx_tea_domain_model_product_tea.fe_group">
+			<trans-unit id="tx_tea_domain_model_tea.fe_group">
 				<source>Usergroup Access Rights</source>
 				<target>Zugriffsrechte für Benutzergruppen</target>
 			</trans-unit>
-			<trans-unit id="tx_tea_domain_model_product_tea.hidden">
+			<trans-unit id="tx_tea_domain_model_tea.hidden">
 				<source>Visible</source>
 				<target>Sichtbar</target>
 			</trans-unit>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -3,28 +3,28 @@
 	<file source-language="en" datatype="plaintext" original="messages">
 		<header/>
 		<body>
-			<trans-unit id="tx_tea_domain_model_product_tea">
+			<trans-unit id="tx_tea_domain_model_tea">
 				<source>Tea</source>
 			</trans-unit>
-			<trans-unit id="tx_tea_domain_model_product_tea.tabs.access">
+			<trans-unit id="tx_tea_domain_model_tea.tabs.access">
 				<source>Access</source>
 			</trans-unit>
-			<trans-unit id="tx_tea_domain_model_product_tea.title">
+			<trans-unit id="tx_tea_domain_model_tea.title">
 				<source>Title</source>
 			</trans-unit>
-			<trans-unit id="tx_tea_domain_model_product_tea.description">
+			<trans-unit id="tx_tea_domain_model_tea.description">
 				<source>Description</source>
 			</trans-unit>
-			<trans-unit id="tx_tea_domain_model_product_tea.image">
+			<trans-unit id="tx_tea_domain_model_tea.image">
 				<source>Image</source>
 			</trans-unit>
-			<trans-unit id="tx_tea_domain_model_product_tea.owner">
+			<trans-unit id="tx_tea_domain_model_tea.owner">
 				<source>Website user who created this record</source>
 			</trans-unit>
-			<trans-unit id="tx_tea_domain_model_product_tea.fe_group">
+			<trans-unit id="tx_tea_domain_model_tea.fe_group">
 				<source>Usergroup Access Rights</source>
 			</trans-unit>
-			<trans-unit id="tx_tea_domain_model_product_tea.hidden">
+			<trans-unit id="tx_tea_domain_model_tea.hidden">
 				<source>Visible</source>
 			</trans-unit>
 		</body>

--- a/Resources/Private/Language/pl.locallang_db.xlf
+++ b/Resources/Private/Language/pl.locallang_db.xlf
@@ -3,31 +3,31 @@
 	<file source-language="en" target-language="pl" datatype="plaintext" original="messages">
 		<header/>
 		<body>
-			<trans-unit id="tx_tea_domain_model_product_tea">
+			<trans-unit id="tx_tea_domain_model_tea">
 				<source>Tea</source>
 				<target>Herbata</target>
 			</trans-unit>
-			<trans-unit id="tx_tea_domain_model_product_tea.tabs.access">
+			<trans-unit id="tx_tea_domain_model_tea.tabs.access">
 				<source>Access</source>
 				<target>Dostęp</target>
 			</trans-unit>
-			<trans-unit id="tx_tea_domain_model_product_tea.title">
+			<trans-unit id="tx_tea_domain_model_tea.title">
 				<source>Title</source>
 				<target>Tytuł</target>
 			</trans-unit>
-			<trans-unit id="tx_tea_domain_model_product_tea.description">
+			<trans-unit id="tx_tea_domain_model_tea.description">
 				<source>Description</source>
 				<target>Opis</target>
 			</trans-unit>
-			<trans-unit id="tx_tea_domain_model_product_tea.image">
+			<trans-unit id="tx_tea_domain_model_tea.image">
 				<source>Image</source>
 				<target>Obraz</target>
 			</trans-unit>
-			<trans-unit id="tx_tea_domain_model_product_tea.owner">
+			<trans-unit id="tx_tea_domain_model_tea.owner">
 				<source>Website user who created this record</source>
 				<target>Użytkownik strony, który utworzył ten rekord</target>
 			</trans-unit>
-			<trans-unit id="tx_tea_domain_model_product_tea.fe_group">
+			<trans-unit id="tx_tea_domain_model_tea.fe_group">
 				<source>Usergroup Access Rights</source>
 				<target>Prawa dostępu grupy użytkowników</target>
 			</trans-unit>

--- a/Tests/Functional/Controller/Fixtures/Database/Teas.csv
+++ b/Tests/Functional/Controller/Fixtures/Database/Teas.csv
@@ -1,4 +1,4 @@
-"tx_tea_domain_model_product_tea"
+"tx_tea_domain_model_tea"
 ,"uid","pid","title"
 ,1,2,"Godesberger Burgtee"
 ,2,2,"Oolong"

--- a/Tests/Functional/Domain/Repository/Fixtures/PersistedTea.csv
+++ b/Tests/Functional/Domain/Repository/Fixtures/PersistedTea.csv
@@ -1,3 +1,3 @@
-"tx_tea_domain_model_product_tea"
+"tx_tea_domain_model_tea"
 ,"uid","title"
 ,1,"Godesberger Burgtee"

--- a/Tests/Functional/Domain/Repository/Fixtures/TeaOnPage.csv
+++ b/Tests/Functional/Domain/Repository/Fixtures/TeaOnPage.csv
@@ -1,3 +1,3 @@
-"tx_tea_domain_model_product_tea"
+"tx_tea_domain_model_tea"
 ,"uid","pid","title"
 ,1,1,"Earl Grey"

--- a/Tests/Functional/Domain/Repository/Fixtures/TeaWithAllScalarData.csv
+++ b/Tests/Functional/Domain/Repository/Fixtures/TeaWithAllScalarData.csv
@@ -1,3 +1,3 @@
-"tx_tea_domain_model_product_tea"
+"tx_tea_domain_model_tea"
 ,"uid","pid","title","description","owner"
 ,1,1,"Earl Grey","Fresh and hot.",2

--- a/Tests/Functional/Domain/Repository/Fixtures/TeaWithImage.csv
+++ b/Tests/Functional/Domain/Repository/Fixtures/TeaWithImage.csv
@@ -1,7 +1,7 @@
-"tx_tea_domain_model_product_tea"
+"tx_tea_domain_model_tea"
 ,"uid","pid","title","image",
 ,1,1,"Gunpowder",1
 
 "sys_file_reference"
 ,"uid","uid_foreign","tablenames","fieldname"
-,1,1,"tx_tea_domain_model_product_tea","image"
+,1,1,"tx_tea_domain_model_tea","image"

--- a/Tests/Functional/Domain/Repository/Fixtures/TeaWithOwner.csv
+++ b/Tests/Functional/Domain/Repository/Fixtures/TeaWithOwner.csv
@@ -1,3 +1,3 @@
-"tx_tea_domain_model_product_tea"
+"tx_tea_domain_model_tea"
 ,"uid","pid","title","owner"
 ,"1","1","Earl Grey",1

--- a/Tests/Functional/Domain/Repository/Fixtures/TeaWithoutOwner.csv
+++ b/Tests/Functional/Domain/Repository/Fixtures/TeaWithoutOwner.csv
@@ -1,3 +1,3 @@
-"tx_tea_domain_model_product_tea"
+"tx_tea_domain_model_tea"
 ,"uid","pid","title","owner"
 ,1,1,"Earl Grey",0

--- a/Tests/Functional/Domain/Repository/Fixtures/TwoTeasWithOwner.csv
+++ b/Tests/Functional/Domain/Repository/Fixtures/TwoTeasWithOwner.csv
@@ -1,4 +1,4 @@
-"tx_tea_domain_model_product_tea"
+"tx_tea_domain_model_tea"
 ,"uid","pid","title","owner"
 ,1,1,"Earl Grey",1
 ,2,1,"Assam",1

--- a/Tests/Functional/Domain/Repository/Fixtures/TwoUnsortedTeas.csv
+++ b/Tests/Functional/Domain/Repository/Fixtures/TwoUnsortedTeas.csv
@@ -1,4 +1,4 @@
-"tx_tea_domain_model_product_tea"
+"tx_tea_domain_model_tea"
 ,"uid","pid","title"
 ,1,1,"Earl Grey"
 ,2,1,"Assam"

--- a/Tests/Functional/Domain/Repository/TeaRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/TeaRepositoryTest.php
@@ -2,17 +2,17 @@
 
 declare(strict_types=1);
 
-namespace TTN\Tea\Tests\Functional\Domain\Repository\Product;
+namespace TTN\Tea\Tests\Functional\Domain\Repository;
 
-use TTN\Tea\Domain\Model\Product\Tea;
-use TTN\Tea\Domain\Repository\Product\TeaRepository;
+use TTN\Tea\Domain\Model\Tea;
+use TTN\Tea\Domain\Repository\TeaRepository;
 use TYPO3\CMS\Extbase\Domain\Model\FileReference;
 use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
 /**
- * @covers \TTN\Tea\Domain\Repository\Product\TeaRepository
- * @covers \TTN\Tea\Domain\Model\Product\Tea
+ * @covers \TTN\Tea\Domain\Repository\TeaRepository
+ * @covers \TTN\Tea\Domain\Model\Tea
  */
 final class TeaRepositoryTest extends FunctionalTestCase
 {
@@ -46,7 +46,7 @@ final class TeaRepositoryTest extends FunctionalTestCase
      */
     public function findAllWithRecordsFindsRecordsFromAllPages(): void
     {
-        $this->importCSVDataSet(__DIR__ . '/../Fixtures/Product/TeaOnPage.csv');
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/TeaOnPage.csv');
 
         $result = $this->subject->findAll();
 
@@ -58,7 +58,7 @@ final class TeaRepositoryTest extends FunctionalTestCase
      */
     public function findAllSortsByTitleInAscendingOrder(): void
     {
-        $this->importCSVDataSet(__DIR__ . '/../Fixtures/Product/TwoUnsortedTeas.csv');
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/TwoUnsortedTeas.csv');
 
         $result = $this->subject->findAll();
 
@@ -81,7 +81,7 @@ final class TeaRepositoryTest extends FunctionalTestCase
      */
     public function findByUidForExistingRecordReturnsModel(): void
     {
-        $this->importCSVDataSet(__DIR__ . '/../Fixtures/Product/TeaWithAllScalarData.csv');
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/TeaWithAllScalarData.csv');
 
         $model = $this->subject->findByUid(1);
 
@@ -93,7 +93,7 @@ final class TeaRepositoryTest extends FunctionalTestCase
      */
     public function findByUidForExistingRecordMapsAllScalarData(): void
     {
-        $this->importCSVDataSet(__DIR__ . '/../Fixtures/Product/TeaWithAllScalarData.csv');
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/TeaWithAllScalarData.csv');
 
         $model = $this->subject->findByUid(1);
         self::assertInstanceOf(Tea::class, $model);
@@ -108,7 +108,7 @@ final class TeaRepositoryTest extends FunctionalTestCase
      */
     public function fillsImageRelation(): void
     {
-        $this->importCSVDataSet(__DIR__ . '/../Fixtures/Product/TeaWithImage.csv');
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/TeaWithImage.csv');
 
         $model = $this->subject->findByUid(1);
 
@@ -129,7 +129,7 @@ final class TeaRepositoryTest extends FunctionalTestCase
         $this->subject->add($model);
         $this->persistenceManager->persistAll();
 
-        $this->assertCSVDataSet(__DIR__ . '/../Fixtures/Product/PersistedTea.csv');
+        $this->assertCSVDataSet(__DIR__ . '/Fixtures/PersistedTea.csv');
     }
 
     /**
@@ -137,7 +137,7 @@ final class TeaRepositoryTest extends FunctionalTestCase
      */
     public function findByOwnerUidFindsTeaWithTheGivenOwnerUid(): void
     {
-        $this->importCSVDataSet(__DIR__ . '/../Fixtures/Product/TeaWithOwner.csv');
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/TeaWithOwner.csv');
 
         $result = $this->subject->findByOwnerUid(1);
 
@@ -149,7 +149,7 @@ final class TeaRepositoryTest extends FunctionalTestCase
      */
     public function findByOwnerUidFindsIgnoresTeaWithNonMatchingOwnerUid(): void
     {
-        $this->importCSVDataSet(__DIR__ . '/../Fixtures/Product/TeaWithOwner.csv');
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/TeaWithOwner.csv');
 
         $result = $this->subject->findByOwnerUid(2);
 
@@ -161,7 +161,7 @@ final class TeaRepositoryTest extends FunctionalTestCase
      */
     public function findByOwnerUidFindsIgnoresTeaWithZeroOwnerUid(): void
     {
-        $this->importCSVDataSet(__DIR__ . '/../Fixtures/Product/TeaWithoutOwner.csv');
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/TeaWithoutOwner.csv');
 
         $result = $this->subject->findByOwnerUid(1);
 
@@ -173,7 +173,7 @@ final class TeaRepositoryTest extends FunctionalTestCase
      */
     public function findByOwnerUidSortsByTitleInAscendingOrder(): void
     {
-        $this->importCSVDataSet(__DIR__ . '/../Fixtures/Product/TwoTeasWithOwner.csv');
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/TwoTeasWithOwner.csv');
 
         $result = $this->subject->findByOwnerUid(1);
 

--- a/Tests/Unit/Controller/FrontEndEditorControllerTest.php
+++ b/Tests/Unit/Controller/FrontEndEditorControllerTest.php
@@ -6,8 +6,8 @@ namespace TTN\Tea\Tests\Unit\Controller;
 
 use PHPUnit\Framework\MockObject\MockObject;
 use TTN\Tea\Controller\FrontEndEditorController;
-use TTN\Tea\Domain\Model\Product\Tea;
-use TTN\Tea\Domain\Repository\Product\TeaRepository;
+use TTN\Tea\Domain\Model\Tea;
+use TTN\Tea\Domain\Repository\TeaRepository;
 use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Context\UserAspect;
 use TYPO3\CMS\Core\Http\HtmlResponse;

--- a/Tests/Unit/Controller/TeaControllerTest.php
+++ b/Tests/Unit/Controller/TeaControllerTest.php
@@ -6,8 +6,8 @@ namespace TTN\Tea\Tests\Unit\Controller;
 
 use PHPUnit\Framework\MockObject\MockObject;
 use TTN\Tea\Controller\TeaController;
-use TTN\Tea\Domain\Model\Product\Tea;
-use TTN\Tea\Domain\Repository\Product\TeaRepository;
+use TTN\Tea\Domain\Model\Tea;
+use TTN\Tea\Domain\Repository\TeaRepository;
 use TYPO3\CMS\Core\Http\HtmlResponse;
 use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;

--- a/Tests/Unit/Domain/Model/TeaTest.php
+++ b/Tests/Unit/Domain/Model/TeaTest.php
@@ -2,19 +2,19 @@
 
 declare(strict_types=1);
 
-namespace TTN\Tea\Tests\Unit\Domain\Model\Product;
+namespace TTN\Tea\Tests\Unit\Domain\Model;
 
-use TTN\Tea\Domain\Model\Product\Tea;
+use TTN\Tea\Domain\Model\Tea;
 use TYPO3\CMS\Extbase\Domain\Model\FileReference;
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
 /**
- * @covers \TTN\Tea\Domain\Model\Product\Tea
+ * @covers \TTN\Tea\Domain\Model\Tea
  */
 final class TeaTest extends UnitTestCase
 {
-    private Tea $subject;
+    private \TTN\Tea\Domain\Model\Tea $subject;
 
     protected function setUp(): void
     {

--- a/Tests/Unit/Domain/Repository/TeaRepositoryTest.php
+++ b/Tests/Unit/Domain/Repository/TeaRepositoryTest.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace TTN\Tea\Tests\Unit\Domain\Repository\Product;
+namespace TTN\Tea\Tests\Unit\Domain\Repository;
 
-use TTN\Tea\Domain\Repository\Product\TeaRepository;
+use TTN\Tea\Domain\Repository\TeaRepository;
 use TYPO3\CMS\Extbase\Object\ObjectManagerInterface;
 use TYPO3\CMS\Extbase\Persistence\Repository;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
 /**
- * @covers \TTN\Tea\Domain\Repository\Product\TeaRepository
+ * @covers \TTN\Tea\Domain\Repository\TeaRepository
  */
 final class TeaRepositoryTest extends UnitTestCase
 {

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -1,4 +1,4 @@
-CREATE TABLE tx_tea_domain_model_product_tea (
+CREATE TABLE tx_tea_domain_model_tea (
     title       varchar(255)     DEFAULT ''  NOT NULL,
     description varchar(2000)    DEFAULT ''  NOT NULL,
     image       int(11) unsigned DEFAULT '0' NOT NULL,


### PR DESCRIPTION
The `Product` namespace segment in the domain model namespace `TTN\Tea\Domain\Model` currently serves no purpose and only adds confusion. So let's simplify the extension structure accordingly.

(I intended to use this to demonstrate DDD contexts, but never built enough models in the Tea extension for this to actually make sense.)

Fixes #1008