### PR TITLE
[BUGFIX] Remove invalid argument quoting in `runTests.sh`

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -468,7 +468,7 @@ case ${TEST_SUITE} in
         cleanTestFiles
         ;;
     composer)
-        COMMAND="composer \"$@\""
+        COMMAND="composer $@"
         ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name composer-command-${SUFFIX} -e COMPOSER_CACHE_DIR=.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} /bin/sh -c "${COMMAND}"
         SUITE_EXIT_CODE=$?
         ;;


### PR DESCRIPTION
`Build/Scripts/runTests.sh` provides a test-suite
`composer` and allows passing additional command
and options directly down to the composer command.

Due to an invalid quoting the passed options were
broking and not regonized by the `composer` binary.

This change removes the superflous argument passing
and therefore allows passing additional options to
the `composer` command.

Resolves: #967