### PR TITLE
[TASK] Drop obsolete Doctrine DBAL development dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,6 @@
 		"typo3/cms-frontend": "^11.5.4 || ^12.4"
 	},
 	"require-dev": {
-		"doctrine/dbal": "^2.13.5 || ^3.6.2",
 		"ergebnis/composer-normalize": "^2.28.3",
 		"friendsofphp/php-cs-fixer": "^3.41.1",
 		"helmich/typo3-typoscript-lint": "^3.1.0",


### PR DESCRIPTION
As we are now using CSV assertions in the functional tests instead of direct database queries, we do not require Doctrine DBAL in the tests anymore.