### PR TITLE
Remove leftover select_key

### DIFF
--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -31,7 +31,7 @@ call_user_func(
         );
 
         // This removes the default controls from the plugin.
-        $controlsToRemove = 'recursive,select_key,pages';
+        $controlsToRemove = 'recursive,pages';
         $GLOBALS['TCA']['tt_content']['types']['list']['subtypes_excludelist']['tea_teaindex'] = $controlsToRemove;
         $GLOBALS['TCA']['tt_content']['types']['list']['subtypes_excludelist']['tea_teashow'] = $controlsToRemove;
         $GLOBALS['TCA']['tt_content']['types']['list']['subtypes_excludelist']['tea_teafrontendeditor'] = $controlsToRemove;


### PR DESCRIPTION
select_key does not exist anymore in the Core and can be safely removed,