### PR TITLE
[FOLLOWUP] Fix path of created tests directory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -159,7 +159,7 @@
 			"@ci:tests:unit",
 			"@ci:tests:functional"
 		],
-		"ci:tests:create-directories": "mkdir -p .Build/public/typo3temp/var/tests",
+		"ci:tests:create-directories": "mkdir -p .Build/Web/typo3temp/var/tests",
 		"ci:tests:functional": [
 			"@ci:tests:create-directories",
 			"find 'Tests/Functional' -wholename '*Test.php' | parallel --gnu 'echo; echo \"Running functional test suite {}\"; .Build/bin/phpunit -c ./Tests/Functional/FunctionalTests.xml {}';"


### PR DESCRIPTION
The document root for the tests is `.Build/Web`, not `.Build/public`.

Followup to #1058