### PR TITLE
[BUGFIX] Avoid JSON-linting the Composer cache directory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -128,7 +128,7 @@
 			"@coverage:create-directories",
 			".Build/bin/phpunit -c ./Tests/Unit/UnitTests.xml --whitelist Classes --coverage-php=.Build/coverage/unit.cov Tests/Unit"
 		],
-		"ci:json:lint": "find . ! -path '*.Build/*' ! -path '*node_modules/*' -name '*.json' | xargs -r php .Build/bin/jsonlint -q",
+		"ci:json:lint": "find . ! -path '*/.cache/*' ! -path '*/.Build/*' ! -path '*/node_modules/*' -name '*.json' | xargs -r php .Build/bin/jsonlint -q",
 		"ci:php": [
 			"@ci:php:cs-fixer",
 			"@ci:php:lint",


### PR DESCRIPTION
Also use stricter exclusion paths to avoid skipping JSON files that we actually want to lint.

This change speeds up JSON lint a lot in cases where Composer from within `runTests.sh` has been used (which creates the `.cache/` directory).

Fixes #1046