### PR TITLE
[BUGFIX] Use extended `sbuerk/demo-core-testing-*` images

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -432,7 +432,7 @@ fi
 mkdir -p .cache
 mkdir -p .Build/Web/typo3temp/var/tests
 
-IMAGE_PHP="ghcr.io/typo3/core-testing-$(echo "php${PHP_VERSION}" | sed -e 's/\.//'):latest"
+IMAGE_PHP="ghcr.io/sbuerk/demo-core-testing-$(echo "php${PHP_VERSION}" | sed -e 's/\.//'):latest"
 IMAGE_ALPINE="docker.io/alpine:3.8"
 IMAGE_DOCS="ghcr.io/t3docs/render-documentation:latest"
 IMAGE_MARIADB="docker.io/mariadb:${DBMS_VERSION}"
@@ -612,12 +612,12 @@ case ${TEST_SUITE} in
         ;;
     update)
         # pull typo3/core-testing-*:latest versions of those ones that exist locally
-        echo "> pull ghcr.io/typo3/core-testing-*:latest versions of those ones that exist locally"
-        ${CONTAINER_BIN} images ghcr.io/typo3/core-testing-*:latest --format "{{.Repository}}:latest" | xargs -I {} ${CONTAINER_BIN} pull {}
+        echo "> pull ghcr.io/sbuerk/demo-core-testing-*:latest versions of those ones that exist locally"
+        ${CONTAINER_BIN} images ghcr.io/sbuerk/demo-core-testing-*:latest --format "{{.Repository}}:latest" | xargs -I {} ${CONTAINER_BIN} pull {}
         echo ""
         # remove "dangling" typo3/core-testing-* images (those tagged as <none>)
-        echo "> remove \"dangling\" ghcr.io/typo3/core-testing-* images (those tagged as <none>)"
-        ${CONTAINER_BIN} images ghcr.io/typo3/core-testing-* --filter "dangling=true" --format "{{.ID}}" | xargs -I {} ${CONTAINER_BIN} rmi {}
+        echo "> remove \"dangling\" ghcr.io/sbuerk/demo-core-testing-* images (those tagged as <none>)"
+        ${CONTAINER_BIN} images ghcr.io/sbuerk/demo-core-testing-* --filter "dangling=true" --format "{{.ID}}" | xargs -I {} ${CONTAINER_BIN} rmi {}
         echo ""
         ;;
     *)


### PR DESCRIPTION
The TYPO3 core testing images only adds stuffs which is
required for the core testing itself and which can be
considered as generic project and extension testing
requirement.

This extension uses advanced `find` options which are
not part of the base busybox provided tools used by
the alpine base image, for example for the `lintYaml`
command in `Build/Scripts/runTests.sh`.

The used `-regextype` option of the `find` binary does
not exists in the stripped down busybox implementation
used by the alpine base images. The `findutils` package
is required to provide the gnu `find` command supporting
this and other advanced options, which can be found as
a solution here:

https://github.com/nextcloud/docker/issues/282

Due to the fact that the additional package will not
make the way into the TYPO3 core images like other
requirements some project or extension may have, a
demonstration github repository has been created some
time ago to demonstrate automatic extended image builds
based on the core testing images. These images already
contains stuff which is required by some projects and
extensions - and the gnu `findutils` package has been
added to these images now with the feature commit

https://github.com/sbuerk/test-image-extend/commit/9f8b125b6add6d54489831ac9684231e3f60b62b

This change switches the used php images from the
`typo3/core-testing-phpXY` images to the extended
`sbuerk/demo-core-testing-phpXY` images.

Can be tested and verified by using

```shell
./Build/Scripts/runTests.sh -s lintYaml
```

with and without this change.

Resolves: #966
