### PR TITLE
[BUGFIX] Ensure removing dangling images works with `podman`

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -617,7 +617,7 @@ case ${TEST_SUITE} in
         echo ""
         # remove "dangling" typo3/core-testing-* images (those tagged as <none>)
         echo "> remove \"dangling\" ghcr.io/sbuerk/demo-core-testing-* images (those tagged as <none>)"
-        ${CONTAINER_BIN} images ghcr.io/sbuerk/demo-core-testing-* --filter "dangling=true" --format "{{.ID}}" | xargs -I {} ${CONTAINER_BIN} rmi {}
+        ${CONTAINER_BIN} images --filter "reference=ghcr.io/sbuerk/demo-core-testing-*" --filter "dangling=true" --format "{{.ID}}" | xargs -I {} ${CONTAINER_BIN} rmi {}
         echo ""
         ;;
     *)


### PR DESCRIPTION
The TYPO3 core `runTests.sh` contains the `-u` option to
update the images and remove dangling images. Providing
an image name and a `--filter` option is not supported
by podmand and has not been discovered yet in the TYPO3
core implementation yet - and adopted with the recently
sync of this repository implementation to the TYPO3 one.

Both supported docker binaries `docker` and `podman`
supportes filtering images using the `reference` filter
option. Therefore, this change modifies the dangling
image remove command to use double filter options.

To verify that double filtering can be used, following
command can be executed if already some images have
been downloaded:

```shell
podman images \
	--filter "reference=ghcr.io/sbuerk/demo-core-testing-*"
	--filter "dangling=false" --format "{{.ID}}"

docker images \
        --filter "reference=ghcr.io/sbuerk/demo-core-testing-*"
        --filter "dangling=false" --format "{{.ID}}"
```

**Note:**	`dangling=false` is used here instead of
		`dangling=true` like in `runTests.sh`

Resolves: #1088
