### PR TITLE
[TASK] Move the PHPUnit configuration files to `Configuration/`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,6 +11,8 @@
 /.phpstorm.meta.php export-ignore
 /.prettierrc.js export-ignore
 /Build/ export-ignore
+/Configuration/FunctionalTests.xml export-ignore
+/Configuration/UnitTests.xml export-ignore
 /Tests/ export-ignore
 /package.json export-ignore
 /phive.xml export-ignore

--- a/Configuration/FunctionalTests.xml
+++ b/Configuration/FunctionalTests.xml
@@ -4,7 +4,7 @@
     xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
     backupGlobals="true"
     beStrictAboutTestsThatDoNotTestAnything="false"
-    bootstrap="../../.Build/vendor/typo3/testing-framework/Resources/Core/Build/UnitTestsBootstrap.php"
+    bootstrap="../.Build/vendor/typo3/testing-framework/Resources/Core/Build/FunctionalTestsBootstrap.php"
     cacheResult="false"
     colors="true"
     convertDeprecationsToExceptions="true"
@@ -14,7 +14,6 @@
     failOnRisky="true"
     failOnWarning="true"
     forceCoversAnnotation="false"
-    processIsolation="false"
     stopOnError="false"
     stopOnFailure="false"
     stopOnIncomplete="false"
@@ -23,7 +22,7 @@
 >
     <coverage/>
     <testsuites>
-        <testsuite name="Unit tests">
+        <testsuite name="Functional tests">
             <!--
                 This path either needs an adaption in extensions, or an extension's
                 test location path needs to be given to phpunit.
@@ -34,6 +33,13 @@
     <php>
         <!-- @deprecated: will be removed with next major version, constant TYPO3_MODE is deprecated -->
         <const name="TYPO3_MODE" value="BE"/>
+        <!--
+            @deprecated: Set this to not suppress warnings, notices and deprecations in functional tests
+                         with TYPO3 core v11 and up.
+                         Will always be done with next major version.
+                         To still suppress warnings, notices and deprecations, do NOT define the constant at all.
+         -->
+        <const name="TYPO3_TESTING_FUNCTIONAL_REMOVE_ERROR_HANDLER" value="true"/>
         <ini name="display_errors" value="1"/>
         <env name="TYPO3_CONTEXT" value="Testing"/>
     </php>

--- a/Configuration/UnitTests.xml
+++ b/Configuration/UnitTests.xml
@@ -4,7 +4,7 @@
     xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
     backupGlobals="true"
     beStrictAboutTestsThatDoNotTestAnything="false"
-    bootstrap="../../.Build/vendor/typo3/testing-framework/Resources/Core/Build/FunctionalTestsBootstrap.php"
+    bootstrap="../.Build/vendor/typo3/testing-framework/Resources/Core/Build/UnitTestsBootstrap.php"
     cacheResult="false"
     colors="true"
     convertDeprecationsToExceptions="true"
@@ -14,6 +14,7 @@
     failOnRisky="true"
     failOnWarning="true"
     forceCoversAnnotation="false"
+    processIsolation="false"
     stopOnError="false"
     stopOnFailure="false"
     stopOnIncomplete="false"
@@ -22,7 +23,7 @@
 >
     <coverage/>
     <testsuites>
-        <testsuite name="Functional tests">
+        <testsuite name="Unit tests">
             <!--
                 This path either needs an adaption in extensions, or an extension's
                 test location path needs to be given to phpunit.
@@ -33,13 +34,6 @@
     <php>
         <!-- @deprecated: will be removed with next major version, constant TYPO3_MODE is deprecated -->
         <const name="TYPO3_MODE" value="BE"/>
-        <!--
-            @deprecated: Set this to not suppress warnings, notices and deprecations in functional tests
-                         with TYPO3 core v11 and up.
-                         Will always be done with next major version.
-                         To still suppress warnings, notices and deprecations, do NOT define the constant at all.
-         -->
-        <const name="TYPO3_TESTING_FUNCTIONAL_REMOVE_ERROR_HANDLER" value="true"/>
         <ini name="display_errors" value="1"/>
         <env name="TYPO3_CONTEXT" value="Testing"/>
     </php>

--- a/composer.json
+++ b/composer.json
@@ -118,7 +118,7 @@
 		"ci:coverage:functional": [
 			"@ci:tests:create-directories",
 			"@coverage:create-directories",
-			".Build/bin/phpunit -c ./Tests/Functional/FunctionalTests.xml --whitelist Classes --coverage-php=.Build/coverage/functional.cov Tests/Functional"
+			".Build/bin/phpunit -c ./Configuration/FunctionalTests.xml --whitelist Classes --coverage-php=.Build/coverage/functional.cov Tests/Functional"
 		],
 		"ci:coverage:merge": [
 			"@coverage:create-directories",
@@ -126,7 +126,7 @@
 		],
 		"ci:coverage:unit": [
 			"@coverage:create-directories",
-			".Build/bin/phpunit -c ./Tests/Unit/UnitTests.xml --whitelist Classes --coverage-php=.Build/coverage/unit.cov Tests/Unit"
+			".Build/bin/phpunit -c ./Configuration/UnitTests.xml --whitelist Classes --coverage-php=.Build/coverage/unit.cov Tests/Unit"
 		],
 		"ci:json:lint": "find . ! -path '*/.cache/*' ! -path '*/.Build/*' ! -path '*/node_modules/*' -name '*.json' | xargs -r php .Build/bin/jsonlint -q",
 		"ci:php": [
@@ -152,9 +152,9 @@
 		"ci:tests:create-directories": "mkdir -p .Build/Web/typo3temp/var/tests",
 		"ci:tests:functional": [
 			"@ci:tests:create-directories",
-			"find 'Tests/Functional' -wholename '*Test.php' | parallel --gnu 'echo; echo \"Running functional test suite {}\"; .Build/bin/phpunit -c ./Tests/Functional/FunctionalTests.xml {}';"
+			"find 'Tests/Functional' -wholename '*Test.php' | parallel --gnu 'echo; echo \"Running functional test suite {}\"; .Build/bin/phpunit -c ./Configuration/FunctionalTests.xml {}';"
 		],
-		"ci:tests:unit": ".Build/bin/phpunit -c ./Tests/Unit/UnitTests.xml Tests/Unit",
+		"ci:tests:unit": ".Build/bin/phpunit -c ./Configuration/UnitTests.xml Tests/Unit",
 		"ci:ts:lint": "typoscript-lint -c Configuration/TsLint.yml --ansi -n --fail-on-warnings -vvv Configuration/TypoScript",
 		"ci:xliff:lint": "php Build/bin/console lint:xliff Resources/Private/Language",
 		"ci:yaml:lint": "find . ! -path '*.Build/*' ! -path '*node_modules/*' -regextype egrep -regex '.*.ya?ml$' | xargs -r php ./.Build/bin/yaml-lint",
@@ -190,6 +190,8 @@
 			"rm .gitignore",
 			"rm .php-cs-fixer.php",
 			"rm .prettierrc.js",
+			"rm Configuration/FunctionalTests.xml",
+			"rm Configuration/UnitTests.xml",
 			"rm package.json",
 			"rm phive.xml",
 			"rm phpcs.xml",


### PR DESCRIPTION
The `Tests/` directory should only include test code, but not the configuration files.

Fixes #1082