### PR TITLE
[TASK] Migrate the deprecated `executeFrontendRequest` in tests

### DIFF
--- a/Tests/Functional/Controller/TeaControllerTest.php
+++ b/Tests/Functional/Controller/TeaControllerTest.php
@@ -44,7 +44,7 @@ final class TeaControllerTest extends FunctionalTestCase
         $request = new InternalRequest();
         $request = $request->withPageId(1);
 
-        $html = $this->executeFrontendRequest($request)->getBody()->__toString();
+        $html = $this->executeFrontendSubRequest($request)->getBody()->__toString();
 
         self::assertStringContainsString('Godesberger Burgtee', $html);
         self::assertStringContainsString('Oolong', $html);


### PR DESCRIPTION
This method is deprecated. Starting with TYPO3 11LTS, `executeFrontendSubRequest` should be used.