### PR TITLE
[TASK] Rework a test communicate its purpose more clearly

### DIFF
--- a/Tests/Functional/Domain/Repository/TeaRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/TeaRepositoryTest.php
@@ -178,6 +178,6 @@ final class TeaRepositoryTest extends FunctionalTestCase
         $result = $this->subject->findByOwnerUid(1);
 
         $result->rewind();
-        self::assertSame(2, $result->current()->getUid());
+        self::assertSame('Assam', $result->current()->getTitle());
     }
 }


### PR DESCRIPTION
When the ordering of items (by title) is verified, checking the title instead of the UID makes this more clear.

Fixes #1132