### PR TITLE
[TASK] Streamline indentation levels of phpstan.neon

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,10 +1,10 @@
 includes:
-    - phpstan-baseline.neon
+  - phpstan-baseline.neon
 
 parameters:
   parallel:
-      # Don't be overly greedy on machines with more CPU's to be a good neighbor especially on CI
-      maximumNumberOfProcesses: 5
+    # Don't be overly greedy on machines with more CPU's to be a good neighbor especially on CI
+    maximumNumberOfProcesses: 5
 
   level: 3
 
@@ -22,6 +22,6 @@ parameters:
     - Tests
 
   type_coverage:
-      return_type: 100
-      param_type: 100
-      property_type: 95
+    return_type: 100
+    param_type: 100
+    property_type: 95


### PR DESCRIPTION
There were mixed indentation levels.
Those are now streamlined to level of 2.
This follows the existing convention for yaml files.