### PR TITLE
[TASK] Add PHPStan extension for cognitive load

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,6 +62,7 @@
 		"symfony/console": "^5.4 || ^6.4 || ^7.0",
 		"symfony/translation": "^5.4 || ^6.4 || ^7.0",
 		"symfony/yaml": "^5.4 || ^6.4 || ^7.0",
+		"tomasvotruba/cognitive-complexity": "^0.2.3",
 		"tomasvotruba/type-coverage": "^0.2.1",
 		"typo3/cms-fluid-styled-content": "^11.5.4 || ^12.4.0",
 		"typo3/coding-standards": "^0.6.1",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -25,3 +25,7 @@ parameters:
     return_type: 100
     param_type: 100
     property_type: 95
+
+  cognitive_complexity:
+    class: 10
+    function: 5


### PR DESCRIPTION
A new composer package "tomasvotruba/cognitive-complexity" is added. This one is a PHPStan extension which will check the cognitive complexity of classes and functions/methods.

We have very low numbers as our examples are not too complex yet. Real projects adopting the extension might configure higher values in the beginning or use the baseline approach.

Resolves: #1154