### PR TITLE
[TASK] Add PHPStan extension for disallowed calls

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,6 +58,7 @@
 		"phpunit/phpunit": "^9.6.16",
 		"saschaegerer/phpstan-typo3": "^1.10.0",
 		"seld/jsonlint": "^1.10.1",
+		"spaze/phpstan-disallowed-calls": "^3.1",
 		"squizlabs/php_codesniffer": "^3.8.1",
 		"symfony/console": "^5.4 || ^6.4 || ^7.0",
 		"symfony/translation": "^5.4 || ^6.4 || ^7.0",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,9 @@
 includes:
   - phpstan-baseline.neon
+  - .Build/vendor/spaze/phpstan-disallowed-calls/disallowed-dangerous-calls.neon
+  - .Build/vendor/spaze/phpstan-disallowed-calls/disallowed-execution-calls.neon
+  - .Build/vendor/spaze/phpstan-disallowed-calls/disallowed-insecure-calls.neon
+  - .Build/vendor/spaze/phpstan-disallowed-calls/disallowed-loose-calls.neon
 
 parameters:
   parallel:
@@ -29,3 +33,26 @@ parameters:
   cognitive_complexity:
     class: 10
     function: 5
+
+  disallowedFunctionCalls:
+    -
+      function:
+        - 'var_dump()'
+        - 'xdebug_break()'
+        - 'debug()'
+      message: 'Use logging instead or remove if it was for debugging purposes.'
+    -
+      function: 'header()'
+      message: 'Use PSR-7 API instead'
+  disallowedStaticCalls:
+    -
+      method: 'TYPO3\CMS\Extbase\Utility\DebuggerUtility::var_dump()'
+      message: 'Use logging instead or remove if it was for debugging purposes.'
+  disallowedSuperglobals:
+    -
+      superglobal:
+        - '$_GET'
+        - '$_POST'
+        - '$_FILES'
+        - '$_SERVER'
+      message: 'Use PSR-7 API instead'


### PR DESCRIPTION
A new composer package "spaze/phpstan-disallowed-calls" is added. This one is a PHPStan extension which will check for forbidden calls. Those calls need to be defined per project.
We use this to prevent debugging and other none good practices from showing up in our code base.

We include the pre defined rules from the package. Those can be argued and adjusted once we hit them.

Resolves: #1158