### PR TITLE
[TASK] Prevent composer.lock file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
           path: ~/.cache/composer
           restore-keys: "php${{ matrix.php-version }}-composer-\n"
       - name: "Install Composer dependencies"
-        run: "composer install --no-progress"
+        run: "composer update --no-progress"
       - name: "Run command"
         run: "composer ci:${{ matrix.command }}"
     strategy:

--- a/.github/workflows/predefined.yml
+++ b/.github/workflows/predefined.yml
@@ -107,7 +107,7 @@ jobs:
           path: ~/.cache/composer
           restore-keys: "php${{ matrix.php-version }}-composer-\n"
       - name: "Install Composer dependencies"
-        run: "composer install --no-progress"
+        run: "composer update --no-progress"
       - name: "Run command"
         run: "composer ci:${{ matrix.command }}"
     strategy:

--- a/.gitlab/pipeline/jobs/build-composer-dependencies.yml
+++ b/.gitlab/pipeline/jobs/build-composer-dependencies.yml
@@ -7,7 +7,7 @@ build-composer-dependencies:
   script:
     - composer --version
     - COMPOSER_CACHE_DIR=.composer
-      composer install --prefer-dist --no-progress --optimize-autoloader
+      composer update --prefer-dist --no-progress --optimize-autoloader
   artifacts:
     when: on_success
     expire_in: 2 weeks

--- a/composer.json
+++ b/composer.json
@@ -95,6 +95,7 @@
 			"typo3/cms-composer-installers": true
 		},
 		"bin-dir": ".Build/bin",
+		"lock": false,
 		"preferred-install": {
 			"*": "dist"
 		},


### PR DESCRIPTION
This is a TYPO3 extension, a library.
We do not track the `composer.lock` file for that reason. Composer itself offers an option to prevent generation of the file. This is now configured to prevent the creation of the file.

That should prevent issues with local version of the file. One might change the `composer.json` version constraints but updates might fail due to locked version constraints.
This no longer happens if no locked version, due to missing lock file, exist.