### PR TITLE
[TASK] Use the development PHP INI on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ matrix.php-version }}"
+          ini-file: development
           coverage: none
           tools: composer:v2
       - name: "Show the Composer configuration"
@@ -47,6 +48,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ matrix.php-version }}"
+          ini-file: development
           coverage: none
           tools: composer:v2
       - name: "Show Composer version"
@@ -105,6 +107,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ matrix.php-version }}"
+          ini-file: development
           coverage: none
           tools: composer:v2
       - name: "Show Composer version"
@@ -203,6 +206,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ matrix.php-version }}"
+          ini-file: development
           tools: composer:v2
           extensions: mysqli
           coverage: none

--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -26,6 +26,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ matrix.php-version }}"
+          ini-file: development
           tools: composer:v2, phive
           extensions: mysqli
           coverage: pcov


### PR DESCRIPTION
This allows us to see (and fail on) more PHP warnings and notices.

Fixes #1197