### PR TITLE
[BUGFIX] Avoid warnings in PHP 8.2/8.3 with lowest dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,8 @@
 		"tomasvotruba/type-coverage": "^0.2.5",
 		"typo3/cms-fluid-styled-content": "^11.5.4 || ^12.4.0",
 		"typo3/coding-standards": "^0.6.1",
-		"typo3/testing-framework": "^7.0.4"
+		"typo3/testing-framework": "^7.0.4",
+		"webmozart/assert": "^1.11.0"
 	},
 	"replace": {
 		"typo3-ter/tea": "self.version"


### PR DESCRIPTION
Lower versions of `webmozart/assert` do not play nice with PHP 8.2/8.3 in our tests.

So require the higher version.