### PR TITLE
[BUGFIX] Raise the minimal TYPO3 V12 version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Raise the minimal TYPO3 V12 version (#1212)
 
 ## 3.1.0
 

--- a/composer.json
+++ b/composer.json
@@ -41,10 +41,10 @@
 	"require": {
 		"php": "~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0",
 		"psr/http-message": "^1.0.1",
-		"typo3/cms-core": "^11.5.4 || ^12.4",
-		"typo3/cms-extbase": "^11.5.4 || ^12.4",
-		"typo3/cms-fluid": "^11.5.4 || ^12.4",
-		"typo3/cms-frontend": "^11.5.4 || ^12.4"
+		"typo3/cms-core": "^11.5.4 || ^12.4.2",
+		"typo3/cms-extbase": "^11.5.4 || ^12.4.2",
+		"typo3/cms-fluid": "^11.5.4 || ^12.4.2",
+		"typo3/cms-frontend": "^11.5.4 || ^12.4.2"
 	},
 	"require-dev": {
 		"ergebnis/composer-normalize": "^2.42.0",
@@ -65,7 +65,7 @@
 		"symfony/yaml": "^5.4 || ^6.4 || ^7.0",
 		"tomasvotruba/cognitive-complexity": "^0.2.3",
 		"tomasvotruba/type-coverage": "^0.2.5",
-		"typo3/cms-fluid-styled-content": "^11.5.4 || ^12.4.0",
+		"typo3/cms-fluid-styled-content": "^11.5.4 || ^12.4.2",
 		"typo3/coding-standards": "^0.6.1",
 		"typo3/testing-framework": "^7.0.4",
 		"webmozart/assert": "^1.11.0"


### PR DESCRIPTION
TYPO3 12.4.2 has some bug fixes for PHP 8.3 to avoid a class loading issue.