### PR TITLE
[BUGFIX] Load realistic, full TypoScript in the controller tests

### DIFF
--- a/Tests/Functional/Controller/TeaControllerTest.php
+++ b/Tests/Functional/Controller/TeaControllerTest.php
@@ -26,8 +26,13 @@ final class TeaControllerTest extends FunctionalTestCase
 
         $this->importCSVDataSet(__DIR__ . '/Fixtures/Database/SiteStructure.csv');
         $this->setUpFrontendRootPage(1, [
+            'constants' => [
+                'EXT:fluid_styled_content/Configuration/TypoScript/constants.typoscript',
+                'EXT:tea/Configuration/TypoScript/constants.typoscript',
+            ],
             'setup' => [
                 'EXT:fluid_styled_content/Configuration/TypoScript/setup.typoscript',
+                'EXT:tea/Configuration/TypoScript/setup.typoscript',
                 'EXT:tea/Tests/Functional/Controller/Fixtures/TypoScript/Setup/Rendering.typoscript',
             ],
         ]);


### PR DESCRIPTION
To be closer to a real-world scenario, we also should load the constants of fluid_styled_content and the constants and setup of our own extension.