### PR TITLE
[TASK] Drop redundant bootstrap information from PHPStan config

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -12,9 +12,6 @@ parameters:
 
   level: 3
 
-  bootstrapFiles:
-    - .Build/vendor/autoload.php
-
   paths:
     - Classes
     - Configuration


### PR DESCRIPTION
This entry is not required - PHPStan already uses the Composer autoloader.

Fixes #1245