### PR TITLE
[TASK] Drop `approved="yes"` from the original locallang files

### DIFF
--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -3,61 +3,61 @@
 	<file source-language="en" datatype="plaintext" original="messages">
 		<header/>
 		<body>
-			<trans-unit id="plugin.tea_index" resname="plugin.tea_index" approved="yes">
+			<trans-unit id="plugin.tea_index" resname="plugin.tea_index">
 				<source>Tea list</source>
 			</trans-unit>
-			<trans-unit id="plugin.tea_show" resname="plugin.tea_show" approved="yes">
+			<trans-unit id="plugin.tea_show" resname="plugin.tea_show">
 				<source>Tea single view</source>
 			</trans-unit>
-			<trans-unit id="plugin.tea_frontend_editor" resname="plugin.tea_frontend_editor" approved="yes">
+			<trans-unit id="plugin.tea_frontend_editor" resname="plugin.tea_frontend_editor">
 				<source>Tea front-end editor</source>
 			</trans-unit>
-			<trans-unit id="plugin.tea.heading" resname="plugin.tea.heading" approved="yes">
+			<trans-unit id="plugin.tea.heading" resname="plugin.tea.heading">
 				<source>Our selection of assorted teas</source>
 			</trans-unit>
-			<trans-unit id="plugin.tea.property.uid" resname="plugin.tea.property.uid" approved="yes">
+			<trans-unit id="plugin.tea.property.uid" resname="plugin.tea.property.uid">
 				<source>UID</source>
 			</trans-unit>
-			<trans-unit id="plugin.tea.property.title" resname="plugin.tea.property.title" approved="yes">
+			<trans-unit id="plugin.tea.property.title" resname="plugin.tea.property.title">
 				<source>Title</source>
 			</trans-unit>
-			<trans-unit id="plugin.frontEndEditor.property.description" resname="plugin.frontEndEditor.property.description" approved="yes">
+			<trans-unit id="plugin.frontEndEditor.property.description" resname="plugin.frontEndEditor.property.description">
 				<source>Description</source>
 			</trans-unit>
-			<trans-unit id="plugin.frontEndEditor.index.heading" resname="plugin.frontEndEditor.index.heading" approved="yes">
+			<trans-unit id="plugin.frontEndEditor.index.heading" resname="plugin.frontEndEditor.index.heading">
 				<source>My teas</source>
 			</trans-unit>
-			<trans-unit id="plugin.frontEndEditor.message.noTeas" resname="plugin.frontEndEditor.message.noTeas" approved="yes">
+			<trans-unit id="plugin.frontEndEditor.message.noTeas" resname="plugin.frontEndEditor.message.noTeas">
 				<source>You have not created any teas yet.</source>
 			</trans-unit>
-			<trans-unit id="plugin.frontEndEditor.property.uid" resname="plugin.frontEndEditor.property.uid" approved="yes">
+			<trans-unit id="plugin.frontEndEditor.property.uid" resname="plugin.frontEndEditor.property.uid">
 				<source>UID</source>
 			</trans-unit>
-			<trans-unit id="plugin.frontEndEditor.property.title" resname="plugin.frontEndEditor.property.title" approved="yes">
+			<trans-unit id="plugin.frontEndEditor.property.title" resname="plugin.frontEndEditor.property.title">
 				<source>Title</source>
 			</trans-unit>
-			<trans-unit id="plugin.frontEndEditor.edit.heading" resname="plugin.frontEndEditor.edit.heading" approved="yes">
+			<trans-unit id="plugin.frontEndEditor.edit.heading" resname="plugin.frontEndEditor.edit.heading">
 				<source>Edit tea</source>
 			</trans-unit>
-			<trans-unit id="plugin.frontEndEditor.action.actions" resname="plugin.frontEndEditor.action.actions" approved="yes">
+			<trans-unit id="plugin.frontEndEditor.action.actions" resname="plugin.frontEndEditor.action.actions">
 				<source>Actions</source>
 			</trans-unit>
-			<trans-unit id="plugin.frontEndEditor.action.edit" resname="plugin.frontEndEditor.action.edit" approved="yes">
+			<trans-unit id="plugin.frontEndEditor.action.edit" resname="plugin.frontEndEditor.action.edit">
 				<source>Edit</source>
 			</trans-unit>
-			<trans-unit id="plugin.frontEndEditor.action.cancel" resname="plugin.frontEndEditor.action.cancel" approved="yes">
+			<trans-unit id="plugin.frontEndEditor.action.cancel" resname="plugin.frontEndEditor.action.cancel">
 				<source>Cancel</source>
 			</trans-unit>
-			<trans-unit id="plugin.frontEndEditor.action.save" resname="plugin.frontEndEditor.action.save" approved="yes">
+			<trans-unit id="plugin.frontEndEditor.action.save" resname="plugin.frontEndEditor.action.save">
 				<source>Save</source>
 			</trans-unit>
-			<trans-unit id="plugin.frontEndEditor.action.new" resname="plugin.frontEndEditor.action.new" approved="yes">
+			<trans-unit id="plugin.frontEndEditor.action.new" resname="plugin.frontEndEditor.action.new">
 				<source>Create new tea</source>
 			</trans-unit>
-			<trans-unit id="plugin.frontEndEditor.action.delete" resname="plugin.frontEndEditor.action.delete" approved="yes">
+			<trans-unit id="plugin.frontEndEditor.action.delete" resname="plugin.frontEndEditor.action.delete">
 				<source>Delete</source>
 			</trans-unit>
-			<trans-unit id="plugin.frontEndEditor.new.heading" resname="plugin.frontEndEditor.new.heading" approved="yes">
+			<trans-unit id="plugin.frontEndEditor.new.heading" resname="plugin.frontEndEditor.new.heading">
 				<source>Create new tea</source>
 			</trans-unit>
 		</body>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -3,28 +3,28 @@
 	<file source-language="en" datatype="plaintext" original="messages">
 		<header/>
 		<body>
-			<trans-unit id="tx_tea_domain_model_tea" resname="tx_tea_domain_model_tea" approved="yes">
+			<trans-unit id="tx_tea_domain_model_tea" resname="tx_tea_domain_model_tea">
 				<source>Tea</source>
 			</trans-unit>
-			<trans-unit id="tx_tea_domain_model_tea.tabs.access" resname="tx_tea_domain_model_tea.tabs.access" approved="yes">
+			<trans-unit id="tx_tea_domain_model_tea.tabs.access" resname="tx_tea_domain_model_tea.tabs.access">
 				<source>Access</source>
 			</trans-unit>
-			<trans-unit id="tx_tea_domain_model_tea.title" resname="tx_tea_domain_model_tea.title" approved="yes">
+			<trans-unit id="tx_tea_domain_model_tea.title" resname="tx_tea_domain_model_tea.title">
 				<source>Title</source>
 			</trans-unit>
-			<trans-unit id="tx_tea_domain_model_tea.description" resname="tx_tea_domain_model_tea.description" approved="yes">
+			<trans-unit id="tx_tea_domain_model_tea.description" resname="tx_tea_domain_model_tea.description">
 				<source>Description</source>
 			</trans-unit>
-			<trans-unit id="tx_tea_domain_model_tea.image" resname="tx_tea_domain_model_tea.image" approved="yes">
+			<trans-unit id="tx_tea_domain_model_tea.image" resname="tx_tea_domain_model_tea.image">
 				<source>Image</source>
 			</trans-unit>
-			<trans-unit id="tx_tea_domain_model_tea.owner" resname="tx_tea_domain_model_tea.owner" approved="yes">
+			<trans-unit id="tx_tea_domain_model_tea.owner" resname="tx_tea_domain_model_tea.owner">
 				<source>Website user who created this record</source>
 			</trans-unit>
-			<trans-unit id="tx_tea_domain_model_tea.fe_group" resname="tx_tea_domain_model_tea.fe_group" approved="yes">
+			<trans-unit id="tx_tea_domain_model_tea.fe_group" resname="tx_tea_domain_model_tea.fe_group">
 				<source>Usergroup Access Rights</source>
 			</trans-unit>
-			<trans-unit id="tx_tea_domain_model_tea.hidden" resname="tx_tea_domain_model_tea.hidden" approved="yes">
+			<trans-unit id="tx_tea_domain_model_tea.hidden" resname="tx_tea_domain_model_tea.hidden">
 				<source>Visible</source>
 			</trans-unit>
 		</body>


### PR DESCRIPTION
The concept of translation approval only applies to translated labels, not to the original labels in English.

Fixes #1257