### PR TITLE
[BUGFIX] Display dbms version for functional test execution

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -646,14 +646,8 @@ echo "TYPO3: ${CORE_VERSION}" >&2
 echo "CONTAINER_BIN: ${CONTAINER_BIN}"
 if [[ ${TEST_SUITE} =~ ^functional$ ]]; then
     case "${DBMS}" in
-        mariadb)
-            echo "DBMS: ${DBMS}  version ${MARIADB_VERSION}  driver ${DATABASE_DRIVER}" >&2
-            ;;
-        mysql)
-            echo "DBMS: ${DBMS}  version ${MYSQL_VERSION}  driver ${DATABASE_DRIVER}" >&2
-            ;;
-        postgres)
-            echo "DBMS: ${DBMS}  version ${POSTGRES_VERSION}" >&2
+        mariadb|mysql|postgres)
+            echo "DBMS: ${DBMS}  version ${DBMS_VERSION}  driver ${DATABASE_DRIVER}" >&2
             ;;
         sqlite)
             echo "DBMS: ${DBMS}" >&2


### PR DESCRIPTION
The `Build/Scripts/runTests.sh` has been streamlined recently
towards the `docker-compose less` approach of the TYPO3 core.
That means, that the `runTest.sh` has been heavily modified,
and multiple changes in the core variant has been implemented.

One of these changes included streamlining the Database Version
handling for the different vendors and combining multiple options
into the `-i` option and using a generic version variable instead
of vendor specific ones. Sadly, it has been missed to align the
version output on the end to the generic variable name.

This change modifies the dbms version output at the end of the
functional test execution to use the correct generic version
variable and thus fixing the missing version information in the
output. The switch has been simplified in the same step.

Resolves: #1272
