### PR TITLE
[BUGFIX] Display static driver info for sqlite and postgres

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -644,11 +644,14 @@ echo "TYPO3: ${CORE_VERSION}" >&2
 echo "CONTAINER_BIN: ${CONTAINER_BIN}"
 if [[ ${TEST_SUITE} =~ ^functional$ ]]; then
     case "${DBMS}" in
-        mariadb|mysql|postgres)
+        mariadb|mysql)
             echo "DBMS: ${DBMS}  version ${DBMS_VERSION}  driver ${DATABASE_DRIVER}" >&2
             ;;
+        postgres)
+            echo "DBMS: ${DBMS}  version ${DBMS_VERSION}  driver pdo_pgsql" >&2
+            ;;
         sqlite)
-            echo "DBMS: ${DBMS}" >&2
+            echo "DBMS: ${DBMS}  driver pdo_sqlite" >&2
             ;;
     esac
 fi


### PR DESCRIPTION
In the PHP world there are only one driver for SQLite and
Postgres available. `runTests.sh` disallows to specify a
driver for SQLite or Postgres and therefore setting the
variable would make that check more complex.

This change modifies the driver information for SQLite and
Postgres to use hardcoded driver output to keep the cross
check for specifing a driver for these database vendors.

Resolves: #1278
