### PR TITLE
[TASK] Use only busybox compatible `find` options

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -162,7 +162,7 @@
 		"ci:tests:unit": ".Build/bin/phpunit -c ./Configuration/UnitTests.xml Tests/Unit",
 		"ci:ts:lint": "typoscript-lint -c Configuration/TsLint.yml --ansi -n --fail-on-warnings -vvv Configuration/TypoScript",
 		"ci:xliff:lint": "php Build/bin/console lint:xliff Resources/Private/Language",
-		"ci:yaml:lint": "find . ! -path '*.Build/*' ! -path '*node_modules/*' -regextype egrep -regex '.*.ya?ml$' | xargs -r php ./.Build/bin/yaml-lint",
+		"ci:yaml:lint": "find . ! -path '*.Build/*' ! -path '*node_modules/*' \\( -name '*.yaml' -o -name '*.yml' \\) | xargs -r php ./.Build/bin/yaml-lint",
 		"coverage:create-directories": "mkdir -p .Build/logs .Build/coverage",
 		"docs:generate": "docker run --rm --pull always -v $(pwd):/project -it ghcr.io/typo3-documentation/render-guides:latest --config=Documentation",
 		"fix:composer:normalize": "@composer normalize --no-check-lock",


### PR DESCRIPTION
`find` has different options in different operating
system implementations (gnu, macosx, busybox, ...).

This change modies the used find command and replace
`-regextype` and `-regex` for multiple file extension
for `ci:yaml:lint` composer script.

Note: That unblocks the ability to revert to the
TYPO3 core-testing-* images and avoid 3rd party
extended images installing `gnu find`.

Resolves: #1209
