### PR TITLE
[BUGFIX] Enhance container documentation rendering

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -520,7 +520,9 @@ case ${TEST_SUITE} in
         SUITE_EXIT_CODE=$?
         ;;
     docsGenerate)
-        ${CONTAINER_BIN} run --rm --pull always -v "$(pwd)":/project -it ${IMAGE_DOCS} --config=Documentation --fail-on-log
+        mkdir -p Documentation-GENERATED-temp
+        chown -R ${HOST_UID}:${HOST_PID} Documentation-GENERATED-temp
+        ${CONTAINER_BIN} run ${CONTAINER_INTERACTIVE} --rm --pull always ${USERSET} -v "${ROOT_DIR}":/project ${IMAGE_DOCS} --config=Documentation --fail-on-log
         SUITE_EXIT_CODE=$?
         ;;
     functional)


### PR DESCRIPTION
The new php based rendering container has been added
recently to render the documentation. The image come
with a internal uid/gid switch to mitigate permission
issues with docker due to a missimplementation, which
podman not suffers by proper using the kernal namespacing.

This change ensures to create a folder before hand with
the correct permissions to mitigate this for docker. On
top of that, the external user set is added for the direct
invokiation and also the interactive switch to avoid failure
in CI context usages.

To avoid permission issues with previously created folder,
a `chown` command is added to ensure correct permission on
that folder.

Resolves: #1283
