### PR TITLE
[BUGFIX] Specify the Node.js version for GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,10 @@ jobs:
     steps:
       - name: "Checkout"
         uses: actions/checkout@v4
+      - name: "Set up Node.js"
+        uses: actions/setup-node@v4
+        with:
+          node-version: "18.20.2"
       - name: "Install modules"
         run: |
           npm ci

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
 	"version": "1.0.0",
 	"license": "ISC",
 	"engines": {
-		"node": ">=18.19.0 <19.0.0",
-		"npm": ">=10.0.0"
+		"node": "^18.20.0",
+		"npm": "^10.5.0"
 	},
 	"scripts": {
 		"lint:js": "eslint 'Resources/Public/**/*.js'",


### PR DESCRIPTION
Also make the required Node.js and NPM versions in `package.json` more specific.