### PR TITLE
[TASK] Switch the license in the package.json to GPL V2

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 	"type": "module",
 	"author": "",
 	"version": "1.0.0",
-	"license": "ISC",
+	"license": "GPL-2.0-or-later",
 	"engines": {
 		"node": "^18.20.0",
 		"npm": "^10.5.0"


### PR DESCRIPTION
TYPO3 Extensions are GPL V2+.
This is already stated in LICENSE and composer.json. For some reason package.json had a different license, which is now streamlined.

Resolves: #1305