### PR TITLE
[TASK] Allow installation of typo3/coding-standards 0.8.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,7 @@ updates:
       - dependency-name: "symfony/translation"
       - dependency-name: "symfony/yaml"
       - dependency-name: "typo3/cms-*"
+      - dependency-name: "typo3/coding-standards"
     versioning-strategy: "increase"
     # adjust this number according to your own milestones if used.
     milestone: 12

--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,7 @@
 		"tomasvotruba/cognitive-complexity": "^0.2.3",
 		"tomasvotruba/type-coverage": "^0.3.1",
 		"typo3/cms-fluid-styled-content": "^11.5.4 || ^12.4.2",
-		"typo3/coding-standards": "^0.6 || ^0.8",
+		"typo3/coding-standards": "^0.6.1 || ^0.8.0",
 		"typo3/testing-framework": "^7.0.5",
 		"webmozart/assert": "^1.11.0"
 	},

--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,7 @@
 		"tomasvotruba/cognitive-complexity": "^0.2.3",
 		"tomasvotruba/type-coverage": "^0.3.1",
 		"typo3/cms-fluid-styled-content": "^11.5.4 || ^12.4.2",
-		"typo3/coding-standards": "^0.6.1",
+		"typo3/coding-standards": "^0.6 || ^0.8",
 		"typo3/testing-framework": "^7.0.5",
 		"webmozart/assert": "^1.11.0"
 	},


### PR DESCRIPTION
This is necessary as older versions block installation of Symfony 7
components.
We also keep 0.6 as 0.8 drops support for older Symfony versions

Resolves: #1113