### PR TITLE
[TASK] Allow additional composer options for `-s composerInstall`

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -495,7 +495,7 @@ case ${TEST_SUITE} in
         SUITE_EXIT_CODE=$?
         ;;
     composerInstall)
-        COMMAND="composer install"
+        COMMAND="composer install $@"
         ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name composer-install-${SUFFIX} -e COMPOSER_CACHE_DIR=.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} /bin/sh -c "${COMMAND}"
         SUITE_EXIT_CODE=$?
         ;;


### PR DESCRIPTION
This change modifies the `Build/Script/runTests.sh` command dispatcher to allow passing composer options to the `composer install` subcommand, for example

  Build/Scripts/runTests.sh -s composerInstall \
    -- --prefer-source

Note that this is already possible using the generic `-s composer` dispatcher but would resolve some user confusion.

This aligns our implementation of runTests.sh with TYPO3 core, see: https://review.typo3.org/c/Packages/TYPO3.CMS/+/84870

Resolves: #1346