### PR TITLE
[FEATURE] Include composer-unused to find unused packages

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,6 +14,7 @@
 /Configuration/FunctionalTests.xml export-ignore
 /Configuration/UnitTests.xml export-ignore
 /Tests/ export-ignore
+/composer-unused.php export-ignore
 /eslint.config.json export-ignore
 /package-lock.json export-ignore
 /package.json export-ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,7 @@ jobs:
         command:
           - "composer:normalize"
           - "composer:psr-verify"
+          - "composer:unused"
           - "json:lint"
           - "php:cs-fixer"
           - "php:sniff"

--- a/composer-unused.php
+++ b/composer-unused.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use ComposerUnused\ComposerUnused\Configuration\Configuration;
+use ComposerUnused\ComposerUnused\Configuration\NamedFilter;
+
+return static function (Configuration $config): Configuration {
+    $config->addNamedFilter(NamedFilter::fromString('typo3/cms-fluid'));
+    $config->addNamedFilter(NamedFilter::fromString('typo3/cms-frontend'));
+    return $config;
+};

--- a/composer.json
+++ b/composer.json
@@ -50,6 +50,7 @@
 		"ergebnis/composer-normalize": "^2.43.0",
 		"friendsofphp/php-cs-fixer": "^3.60.0",
 		"helmich/typo3-typoscript-lint": "^3.1.1",
+		"icanhazstring/composer-unused": "^0.8.11",
 		"php-coveralls/php-coveralls": "^2.7.0",
 		"phpstan/extension-installer": "^1.4.1",
 		"phpstan/phpstan": "^1.11.8",
@@ -117,6 +118,7 @@
 	"scripts": {
 		"ci:composer:normalize": "@composer normalize --no-check-lock --dry-run",
 		"ci:composer:psr-verify": "@composer dumpautoload --optimize --strict-psr --no-plugins",
+		"ci:composer:unused": "composer-unused",
 		"ci:coverage": [
 			"@ci:coverage:unit",
 			"@ci:coverage:functional"
@@ -207,6 +209,7 @@
 	"scripts-descriptions": {
 		"ci:composer:normalize": "Checks the composer.json.",
 		"ci:composer:psr-verify": "Verifies PSR-4 namespace correctness.",
+		"ci:composer:unused": "Finds unused composer packages required in composer.json.",
 		"ci:coverage:functional": "Generates the code coverage report for functional tests.",
 		"ci:coverage:merge": "Merges the code coverage reports for unit and functional tests.",
 		"ci:coverage:unit": "Generates the code coverage report for unit tests.",

--- a/composer.json
+++ b/composer.json
@@ -209,7 +209,7 @@
 	"scripts-descriptions": {
 		"ci:composer:normalize": "Checks the composer.json.",
 		"ci:composer:psr-verify": "Verifies PSR-4 namespace correctness.",
-		"ci:composer:unused": "Finds unused composer packages required in composer.json.",
+		"ci:composer:unused": "Finds unused Composer packages required in composer.json.",
 		"ci:coverage:functional": "Generates the code coverage report for functional tests.",
 		"ci:coverage:merge": "Merges the code coverage reports for unit and functional tests.",
 		"ci:coverage:unit": "Generates the code coverage report for unit tests.",


### PR DESCRIPTION
typo3/cms-fluid and typo3/cms-frontend are ignored because of their indirect usage.
Fixes: #348