### PR TITLE
[TASK] Enable PHPUnit garbage collector control

### DIFF
--- a/Build/phpunit/FunctionalTests.xml
+++ b/Build/phpunit/FunctionalTests.xml
@@ -7,6 +7,7 @@
     bootstrap="../../.Build/vendor/typo3/testing-framework/Resources/Core/Build/FunctionalTestsBootstrap.php"
     cacheResult="false"
     colors="true"
+    controlGarbageCollector="true"
     convertDeprecationsToExceptions="true"
     convertErrorsToExceptions="true"
     convertNoticesToExceptions="true"

--- a/Build/phpunit/UnitTests.xml
+++ b/Build/phpunit/UnitTests.xml
@@ -7,6 +7,7 @@
     bootstrap="../../.Build/vendor/typo3/testing-framework/Resources/Core/Build/UnitTestsBootstrap.php"
     cacheResult="false"
     colors="true"
+    controlGarbageCollector="true"
     convertDeprecationsToExceptions="true"
     convertErrorsToExceptions="true"
     convertNoticesToExceptions="true"


### PR DESCRIPTION
This is disabled by default and enabled with this change. This has the following effect:

- Deactivate automatic garbage collection using gc_disable() before the first test is run
- Trigger garbage collection using gc_collect_cycles() before the first test is run
- Trigger garbage collection using gc_collect_cycles() after each n-th test
- Trigger garbage collection after using gc_collect_cycles() after the last test was run
- Activate automatic garbage collection using gc_enable() after the last test was run

Resolves: #1328