### PR TITLE
[TASK] Use typoscript instead of ts within script names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
           - "php:cs-fixer"
           - "php:sniff"
           - "php:stan"
-          - "ts:lint"
+          - "typoscript:lint"
           - "yaml:lint"
           - "xliff:lint"
         php-version:

--- a/.gitlab/pipeline/.gitlab-ci.yml
+++ b/.gitlab/pipeline/.gitlab-ci.yml
@@ -34,7 +34,7 @@ include:
   - '/.gitlab/pipeline/jobs/php-lint-php8.3.yml'
   - '/.gitlab/pipeline/jobs/phpcs.yml'
   - '/.gitlab/pipeline/jobs/php-cs-fixer.yml'
-  - '/.gitlab/pipeline/jobs/ts-lint.yml'
+  - '/.gitlab/pipeline/jobs/typoscript-lint.yml'
   - '/.gitlab/pipeline/jobs/unit-php7.4-v11-highest.yml'
   - '/.gitlab/pipeline/jobs/unit-php7.4-v11-lowest.yml'
   - '/.gitlab/pipeline/jobs/unit-php8.0-v11-highest.yml'

--- a/.gitlab/pipeline/jobs/typoscript-lint.yml
+++ b/.gitlab/pipeline/jobs/typoscript-lint.yml
@@ -4,4 +4,4 @@ ts-lint:
   needs:
     - build-composer-dependencies
   script:
-    - composer ci:ts:lint
+    - composer ci:typoscript:lint

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -562,7 +562,7 @@ case ${TEST_SUITE} in
         esac
         ;;
     lintTypoScript)
-        COMMAND="composer ci:ts:lint"
+        COMMAND="composer ci:typoscript:lint"
         ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name composer-command-${SUFFIX} -e COMPOSER_CACHE_DIR=.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} /bin/sh -c "${COMMAND}"
         SUITE_EXIT_CODE=$?
         ;;

--- a/Documentation/Running.rst
+++ b/Documentation/Running.rst
@@ -92,10 +92,10 @@ Checks the PHP types using PHPStan.
 
 Runs all static code checks (syntax, style, types).
 
-.. index:: Commands; composer ci:ts:lint
+.. index:: Commands; composer ci:typoscript:lint
 .. code-block:: bash
 
-    composer ci:ts:lint
+    composer ci:typoscript:lint
 
 Lints the TypoScript files.
 

--- a/composer.json
+++ b/composer.json
@@ -154,7 +154,7 @@
 			"@ci:php:lint",
 			"@ci:php:sniff",
 			"@ci:php:stan",
-			"@ci:ts:lint",
+			"@ci:typoscript:lint",
 			"@ci:xliff:lint",
 			"@ci:yaml:lint"
 		],
@@ -164,7 +164,7 @@
 			"find 'Tests/Functional' -wholename '*Test.php' | parallel --gnu 'echo; echo \\\"Running functional test suite {}\\\"; .Build/bin/phpunit -c Build/phpunit/FunctionalTests.xml {}';"
 		],
 		"ci:tests:unit": ".Build/bin/phpunit -c Build/phpunit/UnitTests.xml Tests/Unit",
-		"ci:ts:lint": "typoscript-lint -c Configuration/TsLint.yml --ansi -n --fail-on-warnings -vvv Configuration/TypoScript",
+		"ci:typoscript:lint": "typoscript-lint -c Configuration/TsLint.yml --ansi -n --fail-on-warnings -vvv Configuration/TypoScript",
 		"ci:xliff:lint": "php Build/xliff/xliff-lint lint:xliff Resources/Private/Language",
 		"ci:yaml:lint": "find . ! -path '*.Build/*' ! -path '*node_modules/*' \\( -name '*.yaml' -o -name '*.yml' \\) | xargs -r php ./.Build/bin/yaml-lint",
 		"coverage:create-directories": "mkdir -p .Build/logs .Build/coverage",
@@ -223,7 +223,7 @@
 		"ci:tests:create-directories": "Creates the directories required to smoothely run the functional tests.",
 		"ci:tests:functional": "Runs the functional tests.",
 		"ci:tests:unit": "Runs the unit tests.",
-		"ci:ts:lint": "Lints the TypoScript files.",
+		"ci:typoscript:lint": "Lints the TypoScript files.",
 		"ci:xliff:lint": "Lints the XLIFF files.",
 		"ci:yaml:lint": "Lints the YAML files.",
 		"coverage:create-directories": "Creates the directories needed for recording and merging the code coverage reports.",


### PR DESCRIPTION
As ts is usually understood as TypeScript instead of TypoScript. TYPO3 itself also changed its file extension from `.ts` to `.typoscript`. We reflect that by adopting the script name.

Resolves: #1385