### PR TITLE
[BUGFIX] Remove unavailable PHPUnit configuration option

### DIFF
--- a/Build/phpunit/FunctionalTests.xml
+++ b/Build/phpunit/FunctionalTests.xml
@@ -7,7 +7,6 @@
     bootstrap="../../.Build/vendor/typo3/testing-framework/Resources/Core/Build/FunctionalTestsBootstrap.php"
     cacheResult="false"
     colors="true"
-    controlGarbageCollector="true"
     convertDeprecationsToExceptions="true"
     convertErrorsToExceptions="true"
     convertNoticesToExceptions="true"

--- a/Build/phpunit/UnitTests.xml
+++ b/Build/phpunit/UnitTests.xml
@@ -5,7 +5,6 @@
     beStrictAboutTestsThatDoNotTestAnything="false"
     cacheResult="false"
     colors="true"
-    controlGarbageCollector="true"
     convertDeprecationsToExceptions="true"
     convertErrorsToExceptions="true"
     convertNoticesToExceptions="true"


### PR DESCRIPTION
The PHPUnit configuration option `controlGarbageCollector` was introduced for PHPUnit 10 and 11 only and hence is not available for version 9 yet (the version we're using). So we cannot use this configuration option yet.

This reverts commit 7dea2ddc0beda039c4a7b4944dc1833e097d0a4b.