### PR TITLE
[TASK] Rename npm commands to fit general naming scheme

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
           npm ci
       - name: "Run command"
         run: |
-          npm run lint:${{ matrix.command }}
+          npm run ci:lint:${{ matrix.command }}
   unit-tests:
     name: "Unit tests"
     runs-on: ubuntu-24.04

--- a/.gitlab/pipeline/jobs/javascript-lint.yml
+++ b/.gitlab/pipeline/jobs/javascript-lint.yml
@@ -2,10 +2,10 @@ javascript-lint:
   extends: .default-frontend
   stage: lint
   script:
-    - npm run lint:js
+    - npm run ci:lint:js
 
 style-lint:
   extends: .default-frontend
   stage: lint
   script:
-    - npm run lint:style
+    - npm run ci:lint:style

--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
 		"npm": "^10.5.0"
 	},
 	"scripts": {
-		"lint:js": "eslint 'Resources/Public/**/*.js'",
-		"lint:js:fix": "eslint 'Resources/Public/**/*.js' --quiet --fix",
-		"lint:style": "stylelint Resources/Public/**/*.css",
-		"lint:style:fix": "stylelint Resources/Public/**/*.css --fix"
+		"ci:lint:js": "eslint 'Resources/Public/**/*.js'",
+		"fix:lint:js": "eslint 'Resources/Public/**/*.js' --quiet --fix",
+		"ci:lint:style": "stylelint Resources/Public/**/*.css",
+		"fix:lint:style": "stylelint Resources/Public/**/*.css --fix"
 	},
 	"devDependencies": {
 		"eslint": "^9.2.0",


### PR DESCRIPTION
Commands are now

npm ci:lint:js
npm fix:lint:js
npm ci:lint:style
npm fix:lint:style
