### PR TITLE
[TASK] Rename the CSS lint npm command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
       fail-fast: false
       matrix:
         command:
-          - "style"
+          - "css"
           - "js"
     steps:
       - name: "Checkout"

--- a/.gitlab/pipeline/jobs/javascript-lint.yml
+++ b/.gitlab/pipeline/jobs/javascript-lint.yml
@@ -8,4 +8,4 @@ style-lint:
   extends: .default-frontend
   stage: lint
   script:
-    - npm run ci:lint:style
+    - npm run ci:lint:css

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
 	"scripts": {
 		"ci:lint:js": "eslint 'Resources/Public/**/*.js'",
 		"fix:lint:js": "eslint 'Resources/Public/**/*.js' --quiet --fix",
-		"ci:lint:style": "stylelint Resources/Public/**/*.css",
-		"fix:lint:style": "stylelint Resources/Public/**/*.css --fix"
+		"ci:lint:css": "stylelint Resources/Public/**/*.css",
+		"fix:lint:css": "stylelint Resources/Public/**/*.css --fix"
 	},
 	"devDependencies": {
 		"eslint": "^9.2.0",


### PR DESCRIPTION
The name of the command should reflect the type of file that gets linted.

This is a pre-patch to #1396.