### PR TITLE
[BUGFIX] Broken rendering in docs

### DIFF
--- a/Documentation/Environment.rst
+++ b/Documentation/Environment.rst
@@ -68,6 +68,7 @@ After that you can start the testing distribution using ddev.
     ddev db-import
 
 After that you should be able to access the frontend:
+
 .. code-block:: bash
 
     ddev launch


### PR DESCRIPTION
Add necessary blank line.
The indentation will be rendered as quote otherwise.