### PR TITLE
[TASK] Switch code coverage from PCOV to Xdebug

### DIFF
--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -29,8 +29,7 @@ jobs:
           ini-file: development
           tools: composer:v2, phive
           extensions: mysqli
-          coverage: pcov
-          ini-values: pcov.directory=Classes
+          coverage: xdebug
       - name: "Install development tools"
         run: phive --no-progress install --trust-gpg-keys D8406D0D82947747293778314AA394086372C20A
       - name: "Show Composer version"


### PR DESCRIPTION
PCOV is no longer maintainted, and nowadays Xdebug is fast enough.