### PR TITLE
[TASK] Unify the coverage-related directories

### DIFF
--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -63,7 +63,7 @@ jobs:
       - name: "Run unit tests with coverage"
         run: composer ci:coverage:unit
       - name: "Show generated coverage files"
-        run: "ls -lahR .Build/coverage/"
+        run: "ls -lahR build/coverage/"
       - name: "Run functional tests with coverage"
         run: |
           export typo3DatabaseName="$DB_DATABASE";
@@ -72,7 +72,7 @@ jobs:
           export typo3DatabasePassword="$DB_PASSWORD";
           composer ci:coverage:functional
       - name: "Show generated coverage files"
-        run: "ls -lahR .Build/coverage/"
+        run: "ls -lahR build/coverage/"
       - name: "Merge coverage results"
         run: composer ci:coverage:merge
       - name: "Show combined coverage files"

--- a/composer.json
+++ b/composer.json
@@ -127,15 +127,15 @@
 		"ci:coverage:functional": [
 			"@ci:tests:create-directories",
 			"@coverage:create-directories",
-			"phpunit -c Build/phpunit/FunctionalTests.xml --whitelist Classes --coverage-php=.Build/coverage/functional.cov Tests/Functional"
+			"phpunit -c Build/phpunit/FunctionalTests.xml --whitelist Classes --coverage-php=build/coverage/functional.cov Tests/Functional"
 		],
 		"ci:coverage:merge": [
 			"@coverage:create-directories",
-			"@php tools/phpcov merge --clover=build/logs/clover.xml .Build/coverage/"
+			"@php tools/phpcov merge --clover=build/logs/clover.xml build/coverage/"
 		],
 		"ci:coverage:unit": [
 			"@coverage:create-directories",
-			"phpunit -c Build/phpunit/UnitTests.xml --whitelist Classes --coverage-php=.Build/coverage/unit.cov Tests/Unit"
+			"phpunit -c Build/phpunit/UnitTests.xml --whitelist Classes --coverage-php=build/coverage/unit.cov Tests/Unit"
 		],
 		"ci:json:lint": "find . ! -path '*/.cache/*' ! -path '*/.Build/*' ! -path '*/node_modules/*' -name '*.json' | xargs -r php .Build/bin/jsonlint -q",
 		"ci:php": [
@@ -170,7 +170,7 @@
 		"ci:typoscript:lint": "typoscript-lint -c Configuration/TsLint.yml --ansi -n --fail-on-warnings -vvv Configuration/TypoScript",
 		"ci:xliff:lint": "php Build/xliff/xliff-lint lint:xliff Resources/Private/Language",
 		"ci:yaml:lint": "find . ! -path '*.Build/*' ! -path '*node_modules/*' \\( -name '*.yaml' -o -name '*.yml' \\) | xargs -r php ./.Build/bin/yaml-lint",
-		"coverage:create-directories": "mkdir -p .Build/coverage build/logs",
+		"coverage:create-directories": "mkdir -p build/coverage build/logs",
 		"docs:generate": "docker run --rm --pull always -v $(pwd):/project -it ghcr.io/typo3-documentation/render-guides:latest --config=Documentation",
 		"fix:composer:normalize": "@composer normalize --no-check-lock",
 		"fix:php": [


### PR DESCRIPTION
As we'll need to have `build/logs/` for the merged coverage data anyway, there is no point to have the separate coverage files in `.Build/coverage/` instead of in `build/coverage/`.

Now the setup is more consistent.

Please note that this only affects the CI builds as we usually only collect coverage data there for the pull requests.