### PR TITLE
[TASK] Remove redundancies in the `prepare-release` Composer script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -197,8 +197,6 @@
 			"rm .nvmrc",
 			"rm .php-cs-fixer.php",
 			"rm .prettierrc.js",
-			"rm Build/phpunit/FunctionalTests.xml",
-			"rm Build/phpunit/UnitTests.xml",
 			"rm package-lock.json",
 			"rm package.json",
 			"rm phive.xml",


### PR DESCRIPTION
We're already removing the whole `Build/` directory in this script.

So there is no need to also remove the individual files in this directory.