### PR TITLE
[TASK] Add a time limit to the documentation check on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -326,6 +326,7 @@ jobs:
   documentation:
     name: Documentation
     runs-on: ubuntu-24.04
+    timeout-minutes: 2
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
This will avoid that a hung job will consume up to 30 minutes of CPU time.