### PR TITLE
[TASK] Reorder the PHP-related steps in the `ci:static` script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -154,11 +154,11 @@
 			"@ci:composer:normalize",
 			"@ci:composer:unused",
 			"@ci:json:lint",
-			"@ci:php:cs-fixer",
 			"@ci:php:lint",
 			"@ci:php:rector",
-			"@ci:php:sniff",
 			"@ci:php:stan",
+			"@ci:php:cs-fixer",
+			"@ci:php:sniff",
 			"@ci:typoscript:lint",
 			"@ci:xliff:lint",
 			"@ci:yaml:lint"


### PR DESCRIPTION
Check for syntax errors with PHP lint first, then check for structural problems with Rector and PHPStan, and after that check the coding style.