### PR TITLE
[TASK] Configure Dependabot to create specific commit messages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
     # adjust this number according to your own milestones if used.
     milestone: 12
     commit-message:
-      prefix: "[TASK] "
+      prefix: "[TASK][Dependabot] "
 
   - package-ecosystem: "composer"
     directory: "/"
@@ -30,7 +30,7 @@ updates:
     # adjust this number according to your own milestones if used.
     milestone: 12
     commit-message:
-      prefix: "[TASK] "
+      prefix: "[TASK][Dependabot] "
 
   - package-ecosystem: "npm"
     directory: "/"
@@ -40,4 +40,4 @@ updates:
     # adjust this number according to your own milestones if used.
     milestone: 12
     commit-message:
-      prefix: "[TASK] "
+      prefix: "[TASK][Dependabot] "


### PR DESCRIPTION
We want to be able to easily recognize PRs/commits created by Dependabot.

Fixes #1498